### PR TITLE
Use conda-devenv newly introduced preprocessing selectors to simplify dependency specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ os:
   - linux
 
 env:
-  - CONDA_PY=36
-  - CONDA_PY=37
+  - PY_VER=3.6
+  - PY_VER=3.7
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then OS=Linux-x86_64; else OS=MacOSX-x86_64; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
   matrix:
   # Testing only Debug + Python 3.6 and Release + Python 3.7 so that the number of jobs is still 2 instead of 4.
   - CONFIG: Debug
-    CONDA_PY: 36
+    PY_VER: 3.6
   - CONFIG: Release
-    CONDA_PY: 37
+    PY_VER: 3.7
 cache:
   - C:\Users\appveyor\clcache
 init:

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,6 +1,6 @@
 name: reaktoro
 
-{% set python_version = ".".join(os.environ.get("CONDA_PY", "37")) %}
+{% set py = env(PY_VER) or 3.7 %}
 
 dependencies:
   - boost=1.67
@@ -22,7 +22,7 @@ dependencies:
   - pytest-regressions
   - pytest-timeout
   - pytest-xdist
-  - python={{ python_version }}
+  - python={{ py }}
   - tabulate
   - gxx_linux-64=7.3.0             # [linux]
   - libstdcxx-ng                   # [linux]
@@ -32,12 +32,12 @@ dependencies:
 environment:
 
   PYTHONPATH:
-    - {{ root }}/artifacts/python/lib/python{{ python_version }}/site-packages   # [unix]
-    - {{ root }}/build/lib/python{{ python_version }}/site-packages              # [unix]
-    - {{ root }}/build/lib64/python{{ python_version }}/site-packages            # [unix]
+    - {{ root }}/artifacts/python/lib/python{{ py }}/site-packages   # [unix]
+    - {{ root }}/build/lib/python{{ py }}/site-packages              # [unix]
+    - {{ root }}/build/lib64/python{{ py }}/site-packages            # [unix]
     - {{ root }}\artifacts\python\Lib\site-packages                              # [win]
-    - {{ root }}\build\lib\python{{ python_version }}\site-packages              # [win]
-    - {{ root }}\build\lib64\python{{ python_version }}\site-packages            # [win]
+    - {{ root }}\build\lib\python{{ py }}\site-packages              # [win]
+    - {{ root }}\build\lib64\python{{ py }}\site-packages            # [win]
 
   LD_LIBRARY_PATH: {{ root }}/artifacts/lib # [unix]
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,6 +1,6 @@
 name: reaktoro
 
-{% set py = env('PY_VER') or 3.7 %}
+{% set python_version = ".".join(os.environ.get("CONDA_PY", "37")) %}
 
 dependencies:
   - boost=1.67

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -24,36 +24,21 @@ dependencies:
   - pytest-xdist
   - python={{ python_version }}
   - tabulate
-{% if sys.platform.startswith('linux') %}
-  - gxx_linux-64=7.3.0
-  - libstdcxx-ng
-{% endif %}
-{% if sys.platform.startswith('linux') or sys.platform.startswith('osx') %}
-  - ccache
-{% else %}
-  - clcache
-{% endif %}
+  - gxx_linux-64=7.3.0             # [linux]
+  - libstdcxx-ng                   # [linux]
+  - ccache                         # [unix]
+  - clcache                        # [win]
 
 environment:
-  {% if os.sys.platform != 'win32' %}
 
   PYTHONPATH:
-    - {{ root }}/artifacts/python/lib/python{{ python_version }}/site-packages
-    - {{ root }}/build/lib/python{{ python_version }}/site-packages
-    - {{ root }}/build/lib64/python{{ python_version }}/site-packages
+    - {{ root }}/artifacts/python/lib/python{{ python_version }}/site-packages   # [unix]
+    - {{ root }}/build/lib/python{{ python_version }}/site-packages              # [unix]
+    - {{ root }}/build/lib64/python{{ python_version }}/site-packages            # [unix]
+    - {{ root }}\artifacts\python\Lib\site-packages                              # [win]
+    - {{ root }}\build\lib\python{{ python_version }}\site-packages              # [win]
+    - {{ root }}\build\lib64\python{{ python_version }}\site-packages            # [win]
 
-  # Shared library must be in LD_LIBRARY_PATH in order for `reaktoro` to be successfully imported
-  LD_LIBRARY_PATH:
-    - {{ root }}/artifacts/lib
+  LD_LIBRARY_PATH: {{ root }}/artifacts/lib # [unix]
 
-  {% else %}
-
-  PYTHONPATH:
-    - {{ root }}\artifacts\python\Lib\site-packages
-    - {{ root }}\build\lib\python{{ python_version }}\site-packages
-    - {{ root }}\build\lib64\python{{ python_version }}\site-packages
-
-  PATH:
-    - {{ root }}\artifacts\bin
-
-  {% endif %}
+  PATH: {{ root }}\artifacts\bin # [win]

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,6 +1,6 @@
 name: reaktoro
 
-{% set py = env(PY_VER) or 3.7 %}
+{% set py = env('PY_VER') or 3.7 %}
 
 dependencies:
   - boost=1.67
@@ -35,7 +35,7 @@ environment:
     - {{ root }}/artifacts/python/lib/python{{ py }}/site-packages   # [unix]
     - {{ root }}/build/lib/python{{ py }}/site-packages              # [unix]
     - {{ root }}/build/lib64/python{{ py }}/site-packages            # [unix]
-    - {{ root }}\artifacts\python\Lib\site-packages                              # [win]
+    - {{ root }}\artifacts\python\Lib\site-packages                  # [win]
     - {{ root }}\build\lib\python{{ py }}\site-packages              # [win]
     - {{ root }}\build\lib64\python{{ py }}\site-packages            # [win]
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,6 +1,6 @@
 name: reaktoro
 
-{% set python_version = ".".join(os.environ.get("CONDA_PY", "37")) %}
+{% set py = ".".join(os.environ.get("CONDA_PY", "37")) %}
 
 dependencies:
   - boost=1.67
@@ -39,6 +39,8 @@ environment:
     - {{ root }}\build\lib\python{{ py }}\site-packages              # [win]
     - {{ root }}\build\lib64\python{{ py }}\site-packages            # [win]
 
-  LD_LIBRARY_PATH: {{ root }}/artifacts/lib # [unix]
+  LD_LIBRARY_PATH:                                                   # [unix]
+    - {{ root }}/artifacts/lib                                       # [unix]
 
-  PATH: {{ root }}\artifacts\bin # [win]
+  PATH:                                                              # [win]
+    - {{ root }}\artifacts\bin                                       # [win]

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,6 +1,6 @@
 name: reaktoro
 
-{% set py = ".".join(os.environ.get("CONDA_PY", "37")) %}
+{% set python_version = os.environ.get("PY_VER", "3.7") %}
 
 dependencies:
   - boost=1.67
@@ -22,7 +22,7 @@ dependencies:
   - pytest-regressions
   - pytest-timeout
   - pytest-xdist
-  - python={{ py }}
+  - python={{ python_version }}
   - tabulate
   - gxx_linux-64=7.3.0             # [linux]
   - libstdcxx-ng                   # [linux]
@@ -32,12 +32,12 @@ dependencies:
 environment:
 
   PYTHONPATH:
-    - {{ root }}/artifacts/python/lib/python{{ py }}/site-packages   # [unix]
-    - {{ root }}/build/lib/python{{ py }}/site-packages              # [unix]
-    - {{ root }}/build/lib64/python{{ py }}/site-packages            # [unix]
-    - {{ root }}\artifacts\python\Lib\site-packages                  # [win]
-    - {{ root }}\build\lib\python{{ py }}\site-packages              # [win]
-    - {{ root }}\build\lib64\python{{ py }}\site-packages            # [win]
+    - {{ root }}/artifacts/python/lib/python{{ python_version }}/site-packages   # [unix]
+    - {{ root }}/build/lib/python{{ python_version }}/site-packages              # [unix]
+    - {{ root }}/build/lib64/python{{ python_version }}/site-packages            # [unix]
+    - {{ root }}\artifacts\python\Lib\site-packages                              # [win]
+    - {{ root }}\build\lib\python{{ python_version }}\site-packages              # [win]
+    - {{ root }}\build\lib64\python{{ python_version }}\site-packages            # [win]
 
   LD_LIBRARY_PATH:                                                   # [unix]
     - {{ root }}/artifacts/lib                                       # [unix]


### PR DESCRIPTION
This PR mainly for discussion purposes on the simplification of `environment.devenv.py` in Reaktoro using [conda-devenv experimental support to preprocessing selectors](https://github.com/ESSS/conda-devenv/pull/79). This should also be a starting point for discussing other possible additions into conda-devenv to simplify even further.

If we all agree on the changes in conda-devenv and here, than we merge this PR at some point.