### PR TITLE
Change to always include required pybind11 headers

### DIFF
--- a/python/PyReaktoro/Common/PyAutoDiff.cpp
+++ b/python/PyReaktoro/Common/PyAutoDiff.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ChemicalScalar.hpp>

--- a/python/PyReaktoro/Common/PyIndex.cpp
+++ b/python/PyReaktoro/Common/PyIndex.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Index.hpp>

--- a/python/PyReaktoro/Common/PyMatrix.cpp
+++ b/python/PyReaktoro/Common/PyMatrix.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Math/Matrix.hpp>

--- a/python/PyReaktoro/Common/PyOutputter.cpp
+++ b/python/PyReaktoro/Common/PyOutputter.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Outputter.hpp>

--- a/python/PyReaktoro/Common/PyReactionEquation.cpp
+++ b/python/PyReaktoro/Common/PyReactionEquation.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ReactionEquation.hpp>

--- a/python/PyReaktoro/Common/PyStringList.cpp
+++ b/python/PyReaktoro/Common/PyStringList.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/StringList.hpp>

--- a/python/PyReaktoro/Common/PyUnits.cpp
+++ b/python/PyReaktoro/Common/PyUnits.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Units.hpp>

--- a/python/PyReaktoro/Core/PyChemicalOutput.cpp
+++ b/python/PyReaktoro/Core/PyChemicalOutput.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/StringList.hpp>

--- a/python/PyReaktoro/Core/PyChemicalPlot.cpp
+++ b/python/PyReaktoro/Core/PyChemicalPlot.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/StringList.hpp>

--- a/python/PyReaktoro/Core/PyChemicalProperties.cpp
+++ b/python/PyReaktoro/Core/PyChemicalProperties.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalProperties.hpp>

--- a/python/PyReaktoro/Core/PyChemicalProperty.cpp
+++ b/python/PyReaktoro/Core/PyChemicalProperty.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ReactionEquation.hpp>

--- a/python/PyReaktoro/Core/PyChemicalQuantity.cpp
+++ b/python/PyReaktoro/Core/PyChemicalQuantity.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ChemicalVector.hpp>

--- a/python/PyReaktoro/Core/PyChemicalState.cpp
+++ b/python/PyReaktoro/Core/PyChemicalState.cpp
@@ -15,12 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/eigen.h>
-#include <pybind11/operators.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalProperties.hpp>

--- a/python/PyReaktoro/Core/PyChemicalSystem.cpp
+++ b/python/PyReaktoro/Core/PyChemicalSystem.cpp
@@ -15,13 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalProperties.hpp>

--- a/python/PyReaktoro/Core/PyConnectivity.cpp
+++ b/python/PyReaktoro/Core/PyConnectivity.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalSystem.hpp>

--- a/python/PyReaktoro/Core/PyElement.cpp
+++ b/python/PyReaktoro/Core/PyElement.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/Element.hpp>

--- a/python/PyReaktoro/Core/PyPartition.cpp
+++ b/python/PyReaktoro/Core/PyPartition.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalSystem.hpp>

--- a/python/PyReaktoro/Core/PyPhase.cpp
+++ b/python/PyReaktoro/Core/PyPhase.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ChemicalScalar.hpp>

--- a/python/PyReaktoro/Core/PyReaction.cpp
+++ b/python/PyReaktoro/Core/PyReaction.cpp
@@ -15,12 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/functional.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ChemicalScalar.hpp>

--- a/python/PyReaktoro/Core/PyReactionSystem.cpp
+++ b/python/PyReaktoro/Core/PyReactionSystem.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ChemicalVector.hpp>

--- a/python/PyReaktoro/Core/PySpecies.cpp
+++ b/python/PyReaktoro/Core/PySpecies.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/Element.hpp>

--- a/python/PyReaktoro/Core/PyThermoProperties.cpp
+++ b/python/PyReaktoro/Core/PyThermoProperties.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalSystem.hpp>

--- a/python/PyReaktoro/Core/PyUtils.cpp
+++ b/python/PyReaktoro/Core/PyUtils.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 namespace Reaktoro {
 

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumCompositionProblem.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumCompositionProblem.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Index.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumInverseProblem.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumInverseProblem.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumOptions.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumOptions.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Equilibrium/EquilibriumOptions.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumPath.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumPath.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalOutput.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumProblem.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumProblem.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumResult.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumResult.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Equilibrium/EquilibriumResult.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumSensitivity.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumSensitivity.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Equilibrium/EquilibriumSensitivity.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumSolver.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumSolver.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalProperties.hpp>

--- a/python/PyReaktoro/Equilibrium/PyEquilibriumUtils.cpp
+++ b/python/PyReaktoro/Equilibrium/PyEquilibriumUtils.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>

--- a/python/PyReaktoro/Equilibrium/PySmartEquilibriumSolver.cpp
+++ b/python/PyReaktoro/Equilibrium/PySmartEquilibriumSolver.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalProperties.hpp>

--- a/python/PyReaktoro/Interfaces/PyGems.cpp
+++ b/python/PyReaktoro/Interfaces/PyGems.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Interfaces/Gems.hpp>

--- a/python/PyReaktoro/Interfaces/PyInterface.cpp
+++ b/python/PyReaktoro/Interfaces/PyInterface.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>

--- a/python/PyReaktoro/Interfaces/PyPhreeqc.cpp
+++ b/python/PyReaktoro/Interfaces/PyPhreeqc.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ReactionEquation.hpp>

--- a/python/PyReaktoro/Interfaces/PyPhreeqcEditor.cpp
+++ b/python/PyReaktoro/Interfaces/PyPhreeqcEditor.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/StringList.hpp>

--- a/python/PyReaktoro/Interpreter/PyInterpreter.cpp
+++ b/python/PyReaktoro/Interpreter/PyInterpreter.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Interpreter/Interpreter.hpp>

--- a/python/PyReaktoro/Kinetics/PyKineticOptions.cpp
+++ b/python/PyReaktoro/Kinetics/PyKineticOptions.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Kinetics/KineticOptions.hpp>

--- a/python/PyReaktoro/Kinetics/PyKineticPath.cpp
+++ b/python/PyReaktoro/Kinetics/PyKineticPath.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalOutput.hpp>

--- a/python/PyReaktoro/Kinetics/PyKineticSolver.cpp
+++ b/python/PyReaktoro/Kinetics/PyKineticSolver.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>

--- a/python/PyReaktoro/Math/PyODE.cpp
+++ b/python/PyReaktoro/Math/PyODE.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Math/ODE.hpp>

--- a/python/PyReaktoro/Optimization/PyNonlinearOptions.cpp
+++ b/python/PyReaktoro/Optimization/PyNonlinearOptions.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Optimization/NonlinearSolver.hpp>

--- a/python/PyReaktoro/Optimization/PyOptimumMethod.cpp
+++ b/python/PyReaktoro/Optimization/PyOptimumMethod.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Optimization/OptimumMethod.hpp>

--- a/python/PyReaktoro/Optimization/PyOptimumOptions.cpp
+++ b/python/PyReaktoro/Optimization/PyOptimumOptions.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Optimization/OptimumOptions.hpp>

--- a/python/PyReaktoro/Optimization/PyOptimumResult.cpp
+++ b/python/PyReaktoro/Optimization/PyOptimumResult.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Optimization/OptimumResult.hpp>

--- a/python/PyReaktoro/Optimization/PyOptimumState.cpp
+++ b/python/PyReaktoro/Optimization/PyOptimumState.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Optimization/OptimumState.hpp>

--- a/python/PyReaktoro/PyReaktoro.cpp
+++ b/python/PyReaktoro/PyReaktoro.cpp
@@ -15,8 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include "PyReaktoro.hpp"
+#include <PyReaktoro/PyReaktoro.hpp>
 using namespace Reaktoro;
 
 PYBIND11_MODULE(PyReaktoro, m)

--- a/python/PyReaktoro/PyReaktoro.hpp
+++ b/python/PyReaktoro/PyReaktoro.hpp
@@ -17,6 +17,10 @@
 
 // pybind11 includes
 #include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
 namespace py = pybind11;
 
 namespace Reaktoro {

--- a/python/PyReaktoro/Reactions/PyMineralCatalyst.cpp
+++ b/python/PyReaktoro/Reactions/PyMineralCatalyst.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Reactions/MineralCatalyst.hpp>

--- a/python/PyReaktoro/Reactions/PyMineralMechanism.cpp
+++ b/python/PyReaktoro/Reactions/PyMineralMechanism.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Reactions/MineralMechanism.hpp>

--- a/python/PyReaktoro/Reactions/PyMineralReaction.cpp
+++ b/python/PyReaktoro/Reactions/PyMineralReaction.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ReactionEquation.hpp>

--- a/python/PyReaktoro/Thermodynamics/Common/PyStateOfMatter.cpp
+++ b/python/PyReaktoro/Thermodynamics/Common/PyStateOfMatter.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Common/StateOfMatter.hpp>

--- a/python/PyReaktoro/Thermodynamics/Core/PyChemicalEditor.cpp
+++ b/python/PyReaktoro/Thermodynamics/Core/PyChemicalEditor.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalSystem.hpp>

--- a/python/PyReaktoro/Thermodynamics/Core/PyDatabase.cpp
+++ b/python/PyReaktoro/Thermodynamics/Core/PyDatabase.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/Element.hpp>

--- a/python/PyReaktoro/Thermodynamics/Core/PyThermo.cpp
+++ b/python/PyReaktoro/Thermodynamics/Core/PyThermo.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ThermoScalar.hpp>

--- a/python/PyReaktoro/Thermodynamics/Models/PyAqueousChemicalModelDebyeHuckel.cpp
+++ b/python/PyReaktoro/Thermodynamics/Models/PyAqueousChemicalModelDebyeHuckel.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Models/AqueousChemicalModelDebyeHuckel.hpp>

--- a/python/PyReaktoro/Thermodynamics/Phases/PyAqueousPhase.cpp
+++ b/python/PyReaktoro/Thermodynamics/Phases/PyAqueousPhase.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Mixtures/AqueousMixture.hpp>

--- a/python/PyReaktoro/Thermodynamics/Phases/PyGaseousPhase.cpp
+++ b/python/PyReaktoro/Thermodynamics/Phases/PyGaseousPhase.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Mixtures/GaseousMixture.hpp>

--- a/python/PyReaktoro/Thermodynamics/Phases/PyMineralPhase.cpp
+++ b/python/PyReaktoro/Thermodynamics/Phases/PyMineralPhase.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Mixtures/MineralMixture.hpp>

--- a/python/PyReaktoro/Thermodynamics/Species/PyAqueousSpecies.cpp
+++ b/python/PyReaktoro/Thermodynamics/Species/PyAqueousSpecies.cpp
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Species/AqueousSpecies.hpp>

--- a/python/PyReaktoro/Thermodynamics/Species/PyGaseousSpecies.cpp
+++ b/python/PyReaktoro/Thermodynamics/Species/PyGaseousSpecies.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Species/GaseousSpecies.hpp>

--- a/python/PyReaktoro/Thermodynamics/Species/PyMineralSpecies.cpp
+++ b/python/PyReaktoro/Thermodynamics/Species/PyMineralSpecies.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Thermodynamics/Species/MineralSpecies.hpp>

--- a/python/PyReaktoro/Thermodynamics/Water/PyWater.cpp
+++ b/python/PyReaktoro/Thermodynamics/Water/PyWater.cpp
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Common/ThermoScalar.hpp>

--- a/python/PyReaktoro/Transport/PyTransportSolver.cpp
+++ b/python/PyReaktoro/Transport/PyTransportSolver.cpp
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-// pybind11 includes
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <PyReaktoro/PyReaktoro.hpp>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ChemicalState.hpp>


### PR DESCRIPTION
Picking individual headers from `pybind11` is errorprone, because, if something is missing, it will present errors only at runtime. If we are lucky it will present a nice message asking if we forgot to include something, but sometimes it will fail with hard-to-track problems.

I've noticed that missing an include like `#include <pybind11/stl.h>` in one compilation unit might affect bindings defined in other compilation units (it depends on the order of linkage, sometimes it might happen, sometimes not, and is a very tricky problem to find out).

For a small increment in compilation time, I think it's worthy to have this increased "safety".