### PR TITLE
Remove instructions about configuring the gcc7 label

### DIFF
--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -59,7 +59,6 @@ to a terminal and execute:
 .. code::
 
     conda config --append channels conda-forge
-    conda config --append channels conda-forge/label/gcc7
 
 to add the conda-forge channels required to find the Reaktoro package.
 


### PR DESCRIPTION
This is no longer needed given that conda-forge has finished their migration.