### PR TITLE
Improve CMake so that it won't fail if REAKTORO_PYTHON_INSTALL_PREFIX…

### DIFF
--- a/python/reaktoro/CMakeLists.txt
+++ b/python/reaktoro/CMakeLists.txt
@@ -25,6 +25,9 @@ add_dependencies(reaktoro PyReaktoro)
 if(NOT DEFINED REAKTORO_PYTHON_INSTALL_PREFIX)
     set(REAKTORO_PYTHON_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 endif()
+# If the path is already in Windows format (with backslashes), it can't be added directly
+# to the string below, otherwise CMake will later complain about "Invalid escape sequence".
+file(TO_CMAKE_PATH "${REAKTORO_PYTHON_INSTALL_PREFIX}" REAKTORO_PYTHON_INSTALL_PREFIX)
 
 # Install the reaktoro python package using setuptools
 install(CODE


### PR DESCRIPTION
… is passed as a string and with backslashes.

This is a very minor change, to make it more robust to a problem that I stumbled upon in a conda-forge PR: https://github.com/conda-forge/reaktoro-feedstock/pull/6