### PR TITLE
Warnings' fixes

### DIFF
--- a/Reaktoro/Thermodynamics/Core/Database.cpp
+++ b/Reaktoro/Thermodynamics/Core/Database.cpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <fstream>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Constants.hpp>
@@ -430,9 +431,10 @@ struct Database::Impl
         {
             // Search for a built-in database
             std::string builtin = database(filename);
+            std::ifstream stream(builtin);
 
             // If not empty, use the built-in database to create the xml doc
-            if(!builtin.empty()) result = doc.load(builtin.c_str());
+            if(!builtin.empty()) result = doc.load(stream);
         }
 
         // Ensure either a database file path was correctly given, or a built-in database

--- a/Reaktoro/Thermodynamics/Core/Database.cpp
+++ b/Reaktoro/Thermodynamics/Core/Database.cpp
@@ -431,10 +431,9 @@ struct Database::Impl
         {
             // Search for a built-in database
             std::string builtin = database(filename);
-            std::ifstream stream(builtin);
 
             // If not empty, use the built-in database to create the xml doc
-            if(!builtin.empty()) result = doc.load(stream);
+            if(!builtin.empty()) result = doc.load_string(builtin.c_str());
         }
 
         // Ensure either a database file path was correctly given, or a built-in database

--- a/Reaktoro/Thermodynamics/Core/Database.cpp
+++ b/Reaktoro/Thermodynamics/Core/Database.cpp
@@ -23,7 +23,6 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <fstream>
 
 // Reaktoro includes
 #include <Reaktoro/Common/Constants.hpp>

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -11,6 +11,7 @@ dependencies:
   - ninja
   - numpy
   - pandas
+  - pip
   - pip:
     - sphinx
     - sphinx-autobuild


### PR DESCRIPTION
This PR fixes the following warnings:

1. Warning about deprecated `load` function of `pugixml`
2. pip warning when running `conda devenv`
