### PR TITLE
Add CMake improvements related to Debug builds 

### DIFF
--- a/Reaktoro/CMakeLists.txt
+++ b/Reaktoro/CMakeLists.txt
@@ -47,6 +47,16 @@ install(TARGETS Reaktoro
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries)
 
+# Install debug symbols
+if(MSVC)
+    install(
+        FILES $<TARGET_PDB_FILE:Reaktoro>
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT libraries
+        OPTIONAL
+    )
+endif()
+
 # Install Reaktoro header files
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/Reaktoro
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - clcache -s
   - clcache -z
 build_script:
-  - inv -e compile
+  - inv -e compile --config=%CONFIG% --verbose
   - clcache -s
   - python ci\check_compiled_files.py
 test_script:

--- a/ci/check_compiled_files.py
+++ b/ci/check_compiled_files.py
@@ -3,19 +3,33 @@ Just to test that build is successful and built files are in place.
 '''
 
 from pathlib import Path
+import os
 import sys
+from distutils.sysconfig import get_config_var
+
+
+ext_suffix = get_config_var('EXT_SUFFIX')
+pdb_suffix = '.'.join(ext_suffix.split('.')[:-1] + ['pdb'])
 
 artifacts = (Path(__file__).parent / '../artifacts').absolute()
+
 if sys.platform.startswith('linux'):
     assert (artifacts / 'lib/libReaktoro.so').is_file()
     assert (artifacts / 'include/Reaktoro/Reaktoro.hpp').is_file()
+
 elif sys.platform == 'win32':
     assert (artifacts / 'lib/Reaktoro.lib').is_file()
     assert (artifacts / 'bin/Reaktoro.dll').is_file()
     assert (artifacts / 'include/Reaktoro/Reaktoro.hpp').is_file()
+    assert (artifacts / f'python/Lib/site-packages/reaktoro/PyReaktoro{ext_suffix}').is_file()
+    if os.environ.get('CONFIG', '').lower() == 'debug':
+        assert (artifacts / 'bin/Reaktoro.pdb').is_file()
+        assert (artifacts / f'python/Lib/site-packages/reaktoro/PyReaktoro{pdb_suffix}').is_file()
+
 elif sys.platform == 'darwin':
     assert (artifacts / 'lib/libReaktoro.dylib').is_file()
     assert (artifacts / 'include/Reaktoro/Reaktoro.hpp').is_file()
+
 else:
     assert False, f'Unsupported platform: {sys.platform}'
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -3,12 +3,13 @@
 name: reaktoro
 
 {% set python_version = os.environ.get("PY_VER", "3.7") %}
+{% set debug = os.environ.get("CONFIG", "").lower() == "debug" %}
 
 dependencies:
   - boost=1.70
-  - cmake>=3.13
+  - cmake=3.14
   - invoke
-  - ninja
+  - ninja>=1.9.0
   - numpy
   - pandas
   - pip
@@ -17,7 +18,10 @@ dependencies:
     - sphinx-autobuild
     - sphinx_rtd_theme
     - sphinxcontrib-images
+  {% if not debug %}
+  # Cannot link the Release version of `pugixml` (from conda) to the Debug version of Reaktoro
   - pugixml
+  {% endif %}
   - pybind11=2.3.0
   - pytest
   - pytest-cpp
@@ -41,10 +45,15 @@ environment:
     - {{ root }}/build/lib64/python{{ python_version }}/site-packages            # [unix]
     - {{ root }}\artifacts\python\Lib\site-packages                              # [win]
     - {{ root }}\build\lib\python{{ python_version }}\site-packages              # [win]
-    - {{ root }}\build\lib64\python{{ python_version }}\site-packages            # [win]
 
   LD_LIBRARY_PATH:                                                   # [unix]
     - {{ root }}/artifacts/lib                                       # [unix]
 
   PATH:                                                              # [win]
     - {{ root }}\artifacts\bin                                       # [win]
+
+  CC: clcache                               # [win]
+  CXX: clcache                              # [win]
+  CLCACHE_BASEDIR: {{ root }}               # [win]
+  # Improves CLCACHE robustness, minimizing the chance of a race condition
+  CLCACHE_OBJECT_CACHE_TIMEOUT_MS: 3600000  # [win]

--- a/python/reaktoro/CMakeLists.txt
+++ b/python/reaktoro/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
 # Create a custom target to build reaktoro python package during build stage
 add_custom_target(reaktoro ALL
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:PyReaktoro> 
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:PyReaktoro>
         ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:PyReaktoro>
     COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} --quiet install --prefix=${CMAKE_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -32,8 +32,16 @@ file(TO_CMAKE_PATH "${REAKTORO_PYTHON_INSTALL_PREFIX}" REAKTORO_PYTHON_INSTALL_P
 # Install the reaktoro python package using setuptools
 install(CODE
 "
-	file(TO_NATIVE_PATH \"${REAKTORO_PYTHON_INSTALL_PREFIX}\" REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE)
-	   
+    file(TO_NATIVE_PATH \"${REAKTORO_PYTHON_INSTALL_PREFIX}\" REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE)
+
+    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../../lib/PyReaktoro.pdb)
+        string(REPLACE .pyd .pdb REAKTORO_PDB_FILENAME \"${REAKTORO_PYTHON_MODULE_FILENAME}\")
+
+        execute_process(
+            COMMAND \${CMAKE_COMMAND} -E copy ../../lib/PyReaktoro.pdb \${REAKTORO_PDB_FILENAME}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/python/reaktoro/setup.py.in
+++ b/python/reaktoro/setup.py.in
@@ -9,5 +9,5 @@ setup(name='reaktoro',
       license='LGPLv2.1',
       package_dir={'reaktoro': ''},
       packages=['reaktoro'],
-      package_data={'reaktoro': ['@REAKTORO_PYTHON_MODULE_FILENAME@']}
+      package_data={'reaktoro': ['@REAKTORO_PYTHON_MODULE_FILENAME@', '*.pdb']}
       )

--- a/tasks.py
+++ b/tasks.py
@@ -57,6 +57,7 @@ def _get_cmake_command(
     cmake_generator: str,
     cmake_arch: Optional[str]=None,
     config: str='Release',
+    verbose=False,
     ):
     '''
     :param build_dir: Directory from where cmake will be called.
@@ -84,7 +85,8 @@ def _get_cmake_command(
             -DCMAKE_BUILD_TYPE={config}
             -DCMAKE_INCLUDE_PATH="{cmake_include_path}"
             -DCMAKE_INSTALL_PREFIX="{relative_artifacts_dir.as_posix()}"
-            "-REAKTORO_THIRDPARTY_EXTRA_INSTALL_ARGS=-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+            {f'-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' if verbose else ''}
+            {f'"-DREAKTORO_THIRDPARTY_EXTRA_BUILD_ARGS=-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"' if verbose else ''}
             "{str(relative_root_dir)}"
     """)
 
@@ -116,7 +118,7 @@ if sys.platform.startswith('win'):
 
 
 @task
-def compile(c, clean=False, config='Release', number_of_jobs=-1):
+def compile(c, clean=False, config='Release', number_of_jobs=-1, verbose=False):
     """
     Compiles Reaktoro by running CMake and building with `ninja`.
     Assumes that the environment is already configured using:
@@ -135,6 +137,7 @@ def compile(c, clean=False, config='Release', number_of_jobs=-1):
         artifacts_dir=artifacts_dir,
         cmake_generator="Ninja",
         config=config,
+        verbose=verbose,
     )
     build_command = strip_and_join(f"""
         cmake

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -10,9 +10,8 @@ else()
     set(CXXFLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
-separate_arguments(REAKTORO_THIRDPARTY_INSTALL_ARGS NATIVE_COMMAND "${REAKTORO_THIRDPARTY_INSTALL_ARGS}")
-if (NOT ${THIRDPARTY_EXTRA_BUILD_ARGS} STREQUAL "")
-    separate_arguments(THIRDPARTY_EXTRA_BUILD_ARGS NATIVE_COMMAND "${THIRDPARTY_EXTRA_BUILD_ARGS}")
+if (NOT ${REAKTORO_THIRDPARTY_EXTRA_BUILD_ARGS} STREQUAL "")
+    separate_arguments(REAKTORO_THIRDPARTY_EXTRA_BUILD_ARGS NATIVE_COMMAND "${REAKTORO_THIRDPARTY_EXTRA_BUILD_ARGS}")
 endif()
 
 # Set the common cmake arguments to all external projects
@@ -36,7 +35,7 @@ set(REAKTORO_THIRDPARTY_COMMON_INSTALL_ARGS
      # unused arguments above
     --no-warn-unused-cli
     # Allows the specification of extra args via command-line
-    ${REAKTORO_THIRDPARTY_EXTRA_INSTALL_ARGS}
+    ${REAKTORO_THIRDPARTY_EXTRA_BUILD_ARGS}
     )
 
 # Build and install the pugixml library


### PR DESCRIPTION
 * Fix Debug build in AppVeyor to really be a debug build
 * Improve CMake to install debug symbols (.pdb files)
 * Improve parameter passing to third-party libraries CMake builds (when in Debug and in Windows)
 * Add support (flag) for a more verbose build
