### PR TITLE
Fix optional value compilation error clang9 macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CCache)
 
 # Set the name of the project
-project(Reaktoro VERSION 1.0.5 LANGUAGES CXX)
+project(Reaktoro VERSION 1.0.6 LANGUAGES CXX)
 
 # Check if a conda environment is active
 include(CondaAware)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CCache)
 
 # Set the name of the project
-project(Reaktoro VERSION 1.0.2 LANGUAGES CXX)
+project(Reaktoro VERSION 1.0.5 LANGUAGES CXX)
 
 # Check if a conda environment is active
 include(CondaAware)

--- a/Reaktoro/Interfaces/PhreeqcDatabase.cpp
+++ b/Reaktoro/Interfaces/PhreeqcDatabase.cpp
@@ -410,7 +410,7 @@ auto PhreeqcDatabase::mineralSpecies(std::string name) const -> MineralSpecies
 
 auto PhreeqcDatabase::mineralSpecies() const -> const std::vector<MineralSpecies>&
 {
-	return pimpl->mineral_species;	
+	return pimpl->mineral_species;
 }
 
 auto PhreeqcDatabase::containsAqueousSpecies(std::string name) const -> bool
@@ -531,7 +531,7 @@ auto PhreeqcDatabase::cross(const Database& reference_database) -> Database
             AqueousSpecies refspecies = reference_database.aqueousSpecies(reaktoro_name);
             AqueousSpeciesThermoData data = refspecies.thermoData();
             data.phreeqc = species.thermoData().phreeqc;
-            data.phreeqc.value().reaction = {};
+            data.phreeqc->reaction = {};
             refspecies.setThermoData(data);
             refspecies.setName(species.name());
             return refspecies;
@@ -547,11 +547,11 @@ auto PhreeqcDatabase::cross(const Database& reference_database) -> Database
             AqueousSpeciesThermoData data = species.thermoData();
 
             if(containsAqueousSpecies(alternative))
-                data.phreeqc.value().reaction = aqueousSpecies(alternative).thermoData().phreeqc.value().reaction;
+                data.phreeqc->reaction = aqueousSpecies(alternative).thermoData().phreeqc->reaction;
             if(containsGaseousSpecies(alternative))
-                data.phreeqc.value().reaction = gaseousSpecies(alternative).thermoData().phreeqc.value().reaction;
+                data.phreeqc->reaction = gaseousSpecies(alternative).thermoData().phreeqc->reaction;
             if(containsMineralSpecies(alternative))
-                data.phreeqc.value().reaction = mineralSpecies(alternative).thermoData().phreeqc.value().reaction;
+                data.phreeqc->reaction = mineralSpecies(alternative).thermoData().phreeqc->reaction;
 
             copy.setThermoData(data);
 
@@ -570,7 +570,7 @@ auto PhreeqcDatabase::cross(const Database& reference_database) -> Database
             GaseousSpecies refspecies = reference_database.gaseousSpecies(species.name());
             GaseousSpeciesThermoData data = refspecies.thermoData();
             data.phreeqc = species.thermoData().phreeqc;
-            data.phreeqc.value().reaction = {};
+            data.phreeqc->reaction = {};
             refspecies.setThermoData(data);
             return refspecies;
         }
@@ -586,7 +586,7 @@ auto PhreeqcDatabase::cross(const Database& reference_database) -> Database
             MineralSpecies refspecies = reference_database.mineralSpecies(species.name());
             MineralSpeciesThermoData data = refspecies.thermoData();
             data.phreeqc = species.thermoData().phreeqc;
-            data.phreeqc.value().reaction = {};
+            data.phreeqc->reaction = {};
             refspecies.setThermoData(data);
             return refspecies;
         }

--- a/Reaktoro/Thermodynamics/Core/Database.cpp
+++ b/Reaktoro/Thermodynamics/Core/Database.cpp
@@ -763,9 +763,9 @@ struct Database::Impl
 
         // Check if HKF parameters exist, but they are incomplete
         const auto& hkf = species.thermoData().hkf;
-        if(hkf && !std::isfinite(hkf.value().Gf))
+        if(hkf && !std::isfinite(hkf->Gf))
             return false;
-        if(hkf && !std::isfinite(hkf.value().Hf))
+        if(hkf && !std::isfinite(hkf->Hf))
             return false;
 
         return true;

--- a/Reaktoro/Thermodynamics/Core/Thermo.cpp
+++ b/Reaktoro/Thermodynamics/Core/Thermo.cpp
@@ -162,11 +162,11 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->gibbs_energy.empty())
-            return standardGibbsEnergyFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardGibbsEnergyFromReaction(T, P, species, *reaction_thermo_properties);
 
         const auto phreeqc_thermo_params = getSpeciesThermoParamsPhreeqc(species);
         if(phreeqc_thermo_params)
-			return standardGibbsEnergyFromPhreeqcReaction(T, P, species, phreeqc_thermo_params.value());
+			return standardGibbsEnergyFromPhreeqcReaction(T, P, species, *phreeqc_thermo_params);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).gibbs_energy;
@@ -182,7 +182,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->helmholtz_energy.empty())
-            return standardHelmholtzEnergyFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardHelmholtzEnergyFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).helmholtz_energy;
@@ -198,7 +198,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->internal_energy.empty())
-            return standardInternalEnergyFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardInternalEnergyFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).internal_energy;
@@ -214,7 +214,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->enthalpy.empty())
-            return standardEnthalpyFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardEnthalpyFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).enthalpy;
@@ -230,7 +230,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->entropy.empty())
-            return standardEntropyFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardEntropyFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).entropy;
@@ -246,7 +246,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->volume.empty())
-            return standardVolumeFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardVolumeFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).volume;
@@ -262,7 +262,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->heat_capacity_cp.empty())
-            return standardHeatCapacityConstPFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardHeatCapacityConstPFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).heat_capacity_cp;
@@ -279,7 +279,7 @@ struct Thermo::Impl
 
         const auto reaction_thermo_properties = getReactionInterpolatedThermoProperties(species);
         if(reaction_thermo_properties && !reaction_thermo_properties->heat_capacity_cv.empty())
-            return standardHeatCapacityConstVFromReaction(T, P, species, reaction_thermo_properties.value());
+            return standardHeatCapacityConstVFromReaction(T, P, species, *reaction_thermo_properties);
 
         if(hasThermoParamsHKF(species))
             return species_thermo_state_hkf_fn(T, P, species).heat_capacity_cv;

--- a/Reaktoro/Thermodynamics/Models/SpeciesElectroStateHKF.cpp
+++ b/Reaktoro/Thermodynamics/Models/SpeciesElectroStateHKF.cpp
@@ -126,7 +126,7 @@ auto functionG(Temperature T, Pressure P, const WaterThermoState& wts) -> Functi
 auto speciesElectroStateHKF(const FunctionG& g, const AqueousSpecies& species) -> SpeciesElectroState
 {
     // Get the HKF thermodynamic parameters of the aqueous species
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     // The species electro instance to be calculated
     SpeciesElectroState se;

--- a/Reaktoro/Thermodynamics/Models/SpeciesThermoStateHKF.cpp
+++ b/Reaktoro/Thermodynamics/Models/SpeciesThermoStateHKF.cpp
@@ -84,7 +84,7 @@ template<class SpeciesType>
 auto checkTemperatureValidityHKF(Temperature& T, const SpeciesType& species) -> void
 {
     // Get the HKF thermodynamic data of the species
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     // Check if temperature bounds should be enforced
     if(global::options.exception.enforce_temperature_bounds)
@@ -100,7 +100,7 @@ auto checkTemperatureValidityHKF(Temperature& T, const SpeciesType& species) -> 
 
 auto checkMineralDataHKF(const MineralSpecies& species) -> void
 {
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     const std::string error = "Unable to calculate the thermodynamic properties of mineral species " +
         species.name() + " using the revised HKF equations of state.";
@@ -160,7 +160,7 @@ auto speciesThermoStateSolventHKF(Temperature T, Pressure P, const WaterThermoSt
 auto speciesThermoStateSoluteHKF(Temperature T, Pressure P, const AqueousSpecies& species, const SpeciesElectroState& aes, const WaterElectroState& wes) -> SpeciesThermoState
 {
     // Get the HKF thermodynamic data of the species
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     // Auxiliary variables
     const auto Pbar = P * 1.0e-05;
@@ -260,7 +260,7 @@ auto speciesThermoStateHKF(Temperature T, Pressure P, const FluidSpecies& specie
     checkTemperatureValidityHKF(T, species);
 
     // Get the HKF thermodynamic data of the species
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     // Auxiliary variables
     const auto R    = universalGasConstant;
@@ -316,7 +316,7 @@ auto speciesThermoStateHKF(Temperature T, Pressure P, const MineralSpecies& spec
     checkMineralDataHKF(species);
 
     // Get the HKF thermodynamic data of the species
-    const auto& hkf = species.thermoData().hkf.value();
+    const auto& hkf = *species.thermoData().hkf;
 
     // Auxiliary variables
     const auto  Pb   = P * 1.0e-5;

--- a/python/PyReaktoro/Thermodynamics/Species/PyThermoData.cpp
+++ b/python/PyReaktoro/Thermodynamics/Species/PyThermoData.cpp
@@ -27,8 +27,8 @@ template <typename _Property>
 _Property* get_optional(std::optional<_Property>& prop)
 {
     if (prop.has_value())
-        return &prop.value();
-        
+        return &(*prop);
+
     return nullptr;
 }
 
@@ -36,14 +36,14 @@ void exportThermoData(py::module& m)
 {
     py::class_<SpeciesThermoData>(m, "SpeciesThermoData")
         .def(py::init<>())
-        .def_property("properties", [] (SpeciesThermoData& self) { return get_optional(self.properties);}, 
+        .def_property("properties", [] (SpeciesThermoData& self) { return get_optional(self.properties);},
                                     [] (SpeciesThermoData& self, SpeciesThermoInterpolatedProperties& property) {self.properties = property;} )
         .def_property("reaction", [] (SpeciesThermoData& self) { return get_optional(self.reaction);},
                                   [] (SpeciesThermoData& self, ReactionThermoInterpolatedProperties& property) {self.reaction = property;})
         .def_property("phreeqc", [] (SpeciesThermoData& self) { return get_optional(self.phreeqc);},
                                  [] (SpeciesThermoData& self, SpeciesThermoParamsPhreeqc& property) {self.phreeqc = property;})
         ;
-    
+
     py::class_<AqueousSpeciesThermoData, SpeciesThermoData>(m, "AqueousSpeciesThermoData")
         .def(py::init<>())
         .def_property("hkf", [] (AqueousSpeciesThermoData& self) { return get_optional(self.hkf);},
@@ -58,7 +58,7 @@ void exportThermoData(py::module& m)
 
     m.attr("LiquidSpeciesThermoData") = m.attr("FluidSpeciesThermoData");
     m.attr("GaseousSpeciesThermoData") = m.attr("FluidSpeciesThermoData");
-    
+
     {
         py::class_<MineralSpeciesThermoData, SpeciesThermoData> (m, "MineralSpeciesThermoData")
         .def(py::init<>())
@@ -66,10 +66,10 @@ void exportThermoData(py::module& m)
                              [] (MineralSpeciesThermoData& self, MineralSpeciesThermoParamsHKF& hkf) {self.hkf = hkf;})
         ;
     }
-    
+
 }
 
-void exportThermoDataProperties(py::module& m) 
+void exportThermoDataProperties(py::module& m)
 {
     py::class_<SpeciesThermoInterpolatedProperties>(m, "SpeciesThermoInterpolatedProperties")
         .def(py::init<>())


### PR DESCRIPTION
This PR fixes the compilation issues in conda-forge builds for macOS. This has to do with method `std::optional::value` not being supported on clang9 for macOS. All such uses were replaced by `std::optional::operator*`.

See [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=78862) for more details about the error in the compilation log.

The solution was taken from this [stackoverflow thread](https://stackoverflow.com/questions/44217316/how-do-i-use-stdoptional-in-c?answertab=active#tab-top).