### PR TITLE
Fix clang-9.0.0 compilation error building the python bindings

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -34,6 +34,7 @@ dependencies:
   - tabulate
   - gxx_linux-64=7.3.0             # [linux]
   - libstdcxx-ng                   # [linux]
+  - clangxx=9.0.0                  # [osx]
   - ccache                         # [unix]
   - clcache                        # [win]
 

--- a/python/PyReaktoro/CMakeLists.txt
+++ b/python/PyReaktoro/CMakeLists.txt
@@ -2,6 +2,11 @@
 file(GLOB_RECURSE HEADER_FILES *.hpp)
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 
+# This is needed to avoid some compilation issues when using clang-9 and c++17
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 10.0.0)
+    add_compile_options(-fno-aligned-allocation)
+endif()
+
 # Include the Reaktoro/python directory
 include_directories(${PROJECT_SOURCE_DIR}/python)
 


### PR DESCRIPTION
This PR fixes the build issues in macOS when building `osx`package in conda-forge:

See the errors it fixes [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=78934)

And some here:
 ˜˜˜
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/Common/PyAutoDiff.cpp:18:
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/PyReaktoro.hpp:19:
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/pybind11.h:44:
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/attr.h:13:
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/cast.h:579:34: error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.14 or newer
                        vptr = ::operator new(type->type_size,
                                 ^
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/cast.h:579:34: note: if you supply your own aligned allocation functions, use -faligned-allocation to silence this diagnostic
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/Common/PyAutoDiff.cpp:18:
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/PyReaktoro.hpp:19:
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/pybind11.h:1008:11: error: 'operator delete' is unavailable: introduced in macOS 10.12
        ::operator delete(p, s, std::align_val_t(a));
          ^
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_build_env/bin/../include/c++/v1/new:208:74: note: 'operator delete' has been explicitly marked unavailable here
_LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
                                                                         ^
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/Common/PyAutoDiff.cpp:18:
In file included from /usr/local/miniconda/conda-bld/reaktoro_1570538699443/work/python/PyReaktoro/PyReaktoro.hpp:19:
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/include/python3.6m/pybind11/pybind11.h:1010:11: error: 'operator delete' is unavailable: introduced in macOS 10.12
        ::operator delete(p, s);
          ^
/usr/local/miniconda/conda-bld/reaktoro_1570538699443/_build_env/bin/../include/c++/v1/new:191:74: note: 'operator delete' has been explicitly marked unavailable here
_LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) _NOEXCEPT;         
˜˜˜