### PR TITLE
Refactor devenv file to improve dependency handling

### DIFF
--- a/.dependencies/compilers.devenv.yml
+++ b/.dependencies/compilers.devenv.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - gxx_linux-64=7.3.0             # [linux]
+  - libstdcxx-ng                   # [linux]
+  - clangxx=9.0.0                  # [osx]

--- a/.dependencies/cpp.devenv.yml
+++ b/.dependencies/cpp.devenv.yml
@@ -1,0 +1,9 @@
+{% set debug = os.environ.get("CONFIG", "").lower() == "debug" %}
+
+dependencies:
+  - boost=1.70
+  - pybind11
+  - thermofun
+  {% if not debug %}
+  - pugixml                        # cannot link the Release version of `pugixml` (from conda) to the Debug version of Reaktoro
+  {% endif %}

--- a/.dependencies/docs.devenv.yml
+++ b/.dependencies/docs.devenv.yml
@@ -1,0 +1,8 @@
+dependencies:
+  # - doxygen=1.8.9                 # [linux]
+  - graphviz                       # [linux]
+  - sphinx==1.8.5
+  - sphinx-autobuild
+  - sphinx_rtd_theme
+  - pip:
+    - sphinxcontrib-images

--- a/.dependencies/python.devenv.yml
+++ b/.dependencies/python.devenv.yml
@@ -1,0 +1,8 @@
+{% set python_version = os.environ.get("PY_VER", "3.7") %}
+
+dependencies:
+  - numpy
+  - pandas
+  - pip
+  - tabulate
+  - python={{ python_version }}

--- a/.dependencies/tests.devenv.yml
+++ b/.dependencies/tests.devenv.yml
@@ -1,0 +1,8 @@
+dependencies:
+  - pytest
+  - pytest-cpp
+  - pytest-datadir
+  - pytest-lazy-fixture
+  - pytest-regressions
+  - pytest-timeout
+  - pytest-xdist

--- a/.dependencies/utilities.devenv.yml
+++ b/.dependencies/utilities.devenv.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - cmake=3.15
+  - ninja>=1.9.0
+  - ccache                         # [unix]
+  - clcache                        # [win]
+  - invoke

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -22,10 +22,10 @@ dependencies:
   - pandas
   - pip
   - pip:
-    - sphinx==1.8.5
-    - sphinx-autobuild
-    - sphinx_rtd_theme
     - sphinxcontrib-images
+  - sphinx==1.8.5
+  - sphinx-autobuild
+  - sphinx_rtd_theme
   - pytest
   - pytest-cpp
   - pytest-datadir

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -5,45 +5,13 @@ name: reaktoro
 {% set python_version = os.environ.get("PY_VER", "3.7") %}
 {% set debug = os.environ.get("CONFIG", "").lower() == "debug" %}
 
-dependencies:
-  # Compilers
-  - gxx_linux-64=7.3.0             # [linux]
-  - libstdcxx-ng                   # [linux]
-  - clangxx=9.0.0                  # [osx]
-  # C++ dependendies
-  - boost=1.70
-  - pybind11
-  - thermofun
-  {% if not debug %}
-  - pugixml                        # cannot link the Release version of `pugixml` (from conda) to the Debug version of Reaktoro
-  {% endif %}
-  # Python dependendies
-  - numpy
-  - pandas
-  - pip
-  - pip:
-    - sphinxcontrib-images
-  - sphinx==1.8.5
-  - sphinx-autobuild
-  - sphinx_rtd_theme
-  - pytest
-  - pytest-cpp
-  - pytest-datadir
-  - pytest-lazy-fixture
-  - pytest-regressions
-  - pytest-timeout
-  - pytest-xdist
-  - python={{ python_version }}
-  - tabulate
-  # Doxygen documentation
-  # - doxygen=1.8.9                 # [linux]
-  - graphviz                       # [linux]
-  # Utilities
-  - cmake=3.15
-  - ninja>=1.9.0
-  - ccache                         # [unix]
-  - clcache                        # [win]
-  - invoke
+includes:
+  - {{ root }}/.dependencies/compilers.devenv.yml
+  - {{ root }}/.dependencies/cpp.devenv.yml
+  - {{ root }}/.dependencies/python.devenv.yml
+  - {{ root }}/.dependencies/docs.devenv.yml
+  - {{ root }}/.dependencies/tests.devenv.yml
+  - {{ root }}/.dependencies/utilities.devenv.yml
 
 environment:
 


### PR DESCRIPTION
Hi all,

This PR does a refactor in the `conda-devenv` arrangement:

1. Some `sphinx` deps are available directly through `conda-forge`. Since it's better to have everything from the same place (in the case, `conda-forge`), I moved such deps from `pip` to `conda-forge`;

2. In order to have a better organization, I decomposed `environment.devenv.yml` in several small files, but with a clear purpose for each file. Please check it out at `.dependencies` dir. Now, in the `environment.devenv.yml`, we include files from `.dependencies`. This is an arguable solution, but I believe that this way is better for maintenance.

Feedbacks, reviews and suggestions are heavily welcome.

Cheers!