### PR TITLE
Fix ThermoFun bindings issues

### DIFF
--- a/.dependencies/cpp.devenv.yml
+++ b/.dependencies/cpp.devenv.yml
@@ -3,10 +3,12 @@
 
 dependencies:
   - boost=1.70
-  - pybind11
+  # pybind11 version must match the version used to compile ThermoFun
+  - pybind11 >=2.5.0
   - thermofun
   {% if not debug %}
-  - pugixml                        # cannot link the Release version of `pugixml` (from conda) to the Debug version of Reaktoro
+  # cannot link the Release version of `pugixml` (from conda) to the Debug version of Reaktoro
+  - pugixml
   {% endif %}
   {% if use_openlibm %}
   - openlibm


### PR DESCRIPTION
Some tests were failing because `pybind11` couldn't detect ThermoFun
objects being passed to Reaktoro functions. This was caused by
mismatched versions of pybind11 (2.4.3 in Reaktoro and 2.5.0 in
ThermoFun)