### PR TITLE
Fix inv task "compile" with "clean" build

### DIFF
--- a/.dependencies/python.devenv.yml
+++ b/.dependencies/python.devenv.yml
@@ -5,4 +5,5 @@ dependencies:
   - pandas
   - pip
   - tabulate
+  - colorama
   - python={{ python_version }}

--- a/README.rst
+++ b/README.rst
@@ -153,8 +153,6 @@ Reaktoro using Conda, these are the steps:
 #. Activate the environment: ``source activate reaktoro`` from Linux/macOS or ``activate reaktoro`` from Windows
 #. Create a ``build`` directory and call ``cmake`` from it (for now check the `.travis.yml` file for an example on CMake parameters), OR, on Windows, call the ``inv msvc`` task to generate a project under ``build\msvc`` directory, open it in the IDE and build the ``INSTALL`` project. (``inv`` is short for ``invoke``, from the `Invoke <https://www.pyinvoke.org/>`_ tool.)
 
-Note: an ``inv compile`` task will be added in the future in order to simplify
-compilation in all platforms.
 
 License
 =======


### PR DESCRIPTION
Hey guys! This is a very minor change. 

Details: I have been messing around Reaktoro with some experiments and I have tried a "clean" build (`inv compile --clean`) and it failed. It complained that `colorama` (Python package) was missing. I just added it to Python dependencies.

Cheers!