### PR TITLE
Improve CondaAware.cmake for Unix

### DIFF
--- a/cmake/CondaAware.cmake
+++ b/cmake/CondaAware.cmake
@@ -19,6 +19,18 @@ if(DEFINED ENV{CONDA_PREFIX})
     message(STATUS "CondaAware: conda environment recognized!")
     message(STATUS "CondaAware: CONDA_PREFIX=$ENV{CONDA_PREFIX}")
 
+    # Set python executable to that in the conda environment (unix)
+    if(UNIX AND DEFINED ENV{CONDA_PYTHON_EXE})
+        set(PYTHON_EXECUTABLE "$ENV{CONDA_PREFIX}/bin/python")
+        message(STATUS "CondaAware: PYTHON_EXECUTABLE=CONDA_PREFIX/bin/python (${PYTHON_EXECUTABLE})")
+    endif()
+
+    # Set python executable to that in the conda environment (win)
+    if(WIN32 AND DEFINED ENV{CONDA_PYTHON_EXE})
+        set(PYTHON_EXECUTABLE "$ENV{CONDA_PREFIX}\\python.exe")
+        message(STATUS "CondaAware: PYTHON_EXECUTABLE=CONDA_PREFIX\\python.exe (${PYTHON_EXECUTABLE})")
+    endif()
+
     # Check if in Unix and not in a conda build task
     if(UNIX AND NOT DEFINED ENV{CONDA_BUILD})
         set(CONDA_AWARE_PREFIX "$ENV{CONDA_PREFIX}")


### PR DESCRIPTION
Hey folks!

This PR adds an improved version of `CondaAware.cmake`. I have been facing some problems to install Reaktoro python bindings in the conda env Python on Manjaro OS (Ubuntu is fine). @allanleal kindly provided this version of `CondaAware.cmake` to me. I think this can be beneficial for Reaktoro's users as well.

Thanks!