### PR TITLE
Set cmake project cxx standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CCache)
 
 # Set the name of the project
-project(Reaktoro VERSION 1.0.6 LANGUAGES CXX)
+project(Reaktoro VERSION 1.2.1 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ include(CCache)
 # Set the name of the project
 project(Reaktoro VERSION 1.0.6 LANGUAGES CXX)
 
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+
 # Check if a conda environment is active
 include(CondaAware)
 

--- a/cmake/ReaktoroFindDeps.cmake
+++ b/cmake/ReaktoroFindDeps.cmake
@@ -17,7 +17,6 @@ endif()
 
 # Find pybind11 library (if needed)
 if(REAKTORO_BUILD_PYTHON)
-    set(PYBIND11_CPP_STANDARD -std=c++17)  # Ensure pybind11 really uses c++17
     find_package(pybind11 REQUIRED)
     if(NOT pybind11_FOUND)
         message(WARNING "Could not find pybind11 - the Python module `reaktoro` will not be built.")


### PR DESCRIPTION
Hi, folks.

This is a minor PR.

## Description

In `ReaktoroFindDeps.cmake` script, there is a line that "enforces" `pybind11` to use C++ 17. However, this is raising a warning for me, suggesting to use `CMAKE_CXX_STANDARD` instead. Please check the file [attached here](https://github.com/reaktoro/reaktoro/files/5632193/cmake_output_master.txt) (only shows the first lines of cmake output). More specifically:

```
CMake Warning at /home/diego/Work/miniconda/envs/reaktoro/share/cmake/pybind11/pybind11Common.cmake:174 (message):
  USE -DCMAKE_CXX_STANDARD=17 instead of PYBIND11_CPP_STANDARD
Call Stack (most recent call first):
  /home/diego/Work/miniconda/envs/reaktoro/share/cmake/pybind11/pybind11Config.cmake:249 (include)
  cmake/ReaktoroFindDeps.cmake:21 (find_package)
  CMakeLists.txt:87 (include)
```

I have followed the suggestions. So good, so far!
