### PR TITLE
Enable the use of cvode from a given path using REAKTORO_PATH_TO_CVODE

### DIFF
--- a/Reaktoro/CMakeLists.txt
+++ b/Reaktoro/CMakeLists.txt
@@ -9,8 +9,15 @@ set(REAKTORO_SHARED_LIB ${PROJECT_NAME}${SUFFIX_SHARED_LIBS})
 set(REAKTORO_STATIC_LIB ${PROJECT_NAME}${SUFFIX_STATIC_LIBS})
 
 # Set the list of names of the third-party targets and libraries
-set(THIRDPARTY_TARGETS PUGIXML MINIZ CVODE PHREEQC GEMS)
-set(THIRDPARTY_LIBS pugixml miniz sundials_cvode sundials_nvecserial phreeqc gems nlohmann_json::nlohmann_json)
+set(THIRDPARTY_TARGETS PUGIXML MINIZ PHREEQC GEMS)
+set(THIRDPARTY_LIBS pugixml miniz phreeqc gems nlohmann_json::nlohmann_json)
+
+if(DEFINED REAKTORO_PATH_TO_CVODE)
+    list(APPEND THIRDPARTY_LIBS ${SUNDIALS_CVODE} ${SUNDIALS_NVECSERIAL})
+else()
+    list(APPEND THIRDPARTY_TARGETS CVODE)
+    list(APPEND THIRDPARTY_LIBS sundials_cvode sundials_nvecserial)
+endif()
 
 # Enable automatic creation of a module definition (.def) file for a SHARED library on Windows.
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
@@ -43,6 +50,11 @@ target_link_libraries(Reaktoro
 if(REAKTORO_USE_OPENLIBM)
     configure_target_to_use_openlibm(Reaktoro)
     target_compile_definitions(Reaktoro PUBLIC REAKTORO_USE_OPENLIBM=1)
+endif()
+
+if(REAKTORO_PATH_TO_CVODE)
+    target_include_directories(Reaktoro PRIVATE ${REAKTORO_PATH_TO_CVODE}/include)
+    message(${REAKTORO_PATH_TO_CVODE}/include)
 endif()
 
 # Link Reaktoro library against ThermoFun if found

--- a/cmake/ReaktoroFindDeps.cmake
+++ b/cmake/ReaktoroFindDeps.cmake
@@ -15,6 +15,13 @@ if(ThermoFun_FOUND)
     add_compile_definitions(REAKTORO_USING_THERMOFUN)
 endif()
 
+if(REAKTORO_PATH_TO_CVODE)
+    find_library(SUNDIALS_CVODE sundials_cvode HINTS ${REAKTORO_PATH_TO_CVODE}/lib)
+    find_library(SUNDIALS_NVECSERIAL sundials_nvecserial HINTS ${REAKTORO_PATH_TO_CVODE}/lib)
+    message(SUNDIALS_CVODE = ${SUNDIALS_CVODE})
+    message(SUNDIALS_NVECSERIAL = ${SUNDIALS_NVECSERIAL})
+endif()
+
 # Find pybind11 library (if needed)
 if(REAKTORO_BUILD_PYTHON)
     find_package(pybind11 REQUIRED)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -50,13 +50,15 @@ ExternalProject_Add(MINIZ
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/miniz
     CMAKE_ARGS ${REAKTORO_THIRDPARTY_COMMON_INSTALL_ARGS})
 
-# Build and install the cvode library
-ExternalProject_Add(CVODE
-    PREFIX build
-    URL ${CMAKE_CURRENT_SOURCE_DIR}/cvode/cvode-2.8.2.tar.gz
-    CMAKE_ARGS ${REAKTORO_THIRDPARTY_COMMON_INSTALL_ARGS}
-        -DEXAMPLES_ENABLE=OFF
-        -DEXAMPLES_INSTALL=OFF)
+    # Build and install the cvode library
+if(NOT DEFINED REAKTORO_PATH_TO_CVODE)
+    ExternalProject_Add(CVODE
+        PREFIX build
+        URL ${CMAKE_CURRENT_SOURCE_DIR}/cvode/cvode-2.8.2.tar.gz
+        CMAKE_ARGS ${REAKTORO_THIRDPARTY_COMMON_INSTALL_ARGS}
+            -DEXAMPLES_ENABLE=OFF
+            -DEXAMPLES_INSTALL=OFF)
+endif()
 
 # Build and install the Phreeqc library
 ExternalProject_Add(PHREEQC


### PR DESCRIPTION
This PR is a fix to issue #179 .

To use `cvode` from a given installation location, do:

~~~
mkdir build && cd build
cmake .. -DREAKTORO_PATH_TO_CVODE=/home/user/codes/cvode-2.8.2/build/install
make -j
~~~

Note: Do not add `/` to the end of `/home/user/codes/cvode-2.8.2/build/install`.

By defining the cmake variable `REAKTORO_PATH_TO_CVODE`, this will skip the automatic build of cvode and use the libraries `libsundials_cvode.so` and `libsundials_nvecserial.so` available in `path/to/install/lib`. The header files should be in `/path/to/install/include`.