### PR TITLE
Use MatrixXd to construct BIPs matrices instead of ThermoScalar based approach

### DIFF
--- a/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
+++ b/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
@@ -261,9 +261,9 @@ struct CubicEOS::Impl
         {
             for(unsigned j = 0; j < nspecies; ++j)
             {
-                const double r = kres.k.size() ? 1.0 - kres.k(i, j) : 1.0;
-                const double rT = kres.kT.size() ? -kres.kT(i, j) : 0.0;
-                const double rTT = kres.kTT.size() ? -kres.kTT(i, j) : 0.0;
+                const ThermoScalar r = kres.k.size() ? ThermoScalar(1.0 - kres.k(i, j)) : ThermoScalar(1.0);
+                const ThermoScalar rT = kres.kT.size() ? ThermoScalar(-kres.kT(i, j)) : ThermoScalar(0.0);
+                const ThermoScalar rTT = kres.kTT.size() ? ThermoScalar(-kres.kTT(i, j)) : ThermoScalar(0.0);
 
                 const ThermoScalar s = sqrt(a[i]*a[j]);
                 const ThermoScalar sT = 0.5*s/(a[i]*a[j]) * (aT[i]*a[j] + a[i]*aT[j]);

--- a/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
+++ b/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
@@ -511,7 +511,7 @@ auto sanityCheckInteractionParamsFunction(const unsigned& nspecies, const CubicE
 
         // Check k's symmetry
         for (unsigned i = 0; i < k_num_of_rows; i++){
-            for (auto j = i; j < k_num_of_cols; j++){
+            for (auto j = i + 1; j < k_num_of_cols; j++){
                 Assert(bips.k(i, j) == bips.k(j, i),
                     "BIPs matrix k is not symmetric.", "Check your k BIPs matrix input."
                 );
@@ -536,7 +536,7 @@ auto sanityCheckInteractionParamsFunction(const unsigned& nspecies, const CubicE
 
         // Check kT's symmetry
         for (unsigned i = 0; i < kT_num_of_rows; i++){
-            for (auto j = i; j < kT_num_of_cols; j++){
+            for (auto j = i + 1; j < kT_num_of_cols; j++){
                 Assert(bips.kT(i, j) == bips.kT(j, i),
                     "BIPs matrix kT is not symmetric.", "Check your kT BIPs matrix input.");
             }
@@ -560,7 +560,7 @@ auto sanityCheckInteractionParamsFunction(const unsigned& nspecies, const CubicE
 
         // Check kTT's symmetry
         for (unsigned i = 0; i < kTT_num_of_rows; i++){
-            for (auto j = i; j < kTT_num_of_cols; j++){
+            for (auto j = i + 1; j < kTT_num_of_cols; j++){
                 Assert(bips.kT(i, j) == bips.kT(j, i),
                     "BIPs matrix kT is not symmetric.", "Check your kT BIPs matrix input."
                 );

--- a/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
+++ b/Reaktoro/Thermodynamics/EOS/CubicEOS.cpp
@@ -541,12 +541,6 @@ auto sanityCheckInteractionParamsFunction(const unsigned& nspecies, const CubicE
                     "BIPs matrix kT is not symmetric.", "Check your kT BIPs matrix input.");
             }
         }
-
-        // Check kT dimensions with k
-        Assert(kT_size == k_size, 
-            "BIPs matrices k and kT have different dimensions.",
-            "k dimensions (" + std::to_string(bips.k.rows()) + "," + std::to_string(bips.k.rows()) + "). " +
-            "kT dimensions (" + std::to_string(kT_num_of_rows) + "," + std::to_string(kT_num_of_rows) + ").");
     }
 
     // Check kTT's dimensions
@@ -566,12 +560,6 @@ auto sanityCheckInteractionParamsFunction(const unsigned& nspecies, const CubicE
                 );
             }
         }
-
-        // Check kTT dimensions with k
-        Assert(kTT_size == k_size, 
-            "BIPs matrices k and kTT have different dimensions.",
-            "k dimensions (" + std::to_string(bips.k.rows()) + "," + std::to_string(bips.k.rows()) + "). " +
-            "kT dimensions (" + std::to_string(kTT_num_of_rows) + "," + std::to_string(kTT_num_of_rows) + ").");
     }
 }
 

--- a/Reaktoro/Thermodynamics/EOS/CubicEOS.hpp
+++ b/Reaktoro/Thermodynamics/EOS/CubicEOS.hpp
@@ -50,16 +50,16 @@ public:
     /// Note that the BIPs can depend on the temperature, thus kT and kTT should be also provided.
     struct InteractionParamsResult
     {
-        Table2D<ThermoScalar> k;
+        MatrixXd k;
 
-        Table2D<ThermoScalar> kT;
+        MatrixXd kT;
 
-        Table2D<ThermoScalar> kTT;
+        MatrixXd kTT;
     };
 
     /// Function wrapper to calculate (temperature-dependent) binary interaction parameters.
     using InteractionParamsFunction =
-        std::function<InteractionParamsResult(const ThermoScalar&)>;
+        std::function<InteractionParamsResult(const double&)>;
 
     /// Parameters to be passed to the Cubic Equation of State
     struct Params

--- a/python/PyReaktoro/Thermodynamics/Models/PyCubicEOS.cpp
+++ b/python/PyReaktoro/Thermodynamics/Models/PyCubicEOS.cpp
@@ -52,10 +52,10 @@ void exportCubicEOS(py::module& m)
 
     py::class_<CubicEOS::InteractionParamsResult>(m, "BinaryInteractionParams")
         .def(
-            py::init<Table2D<ThermoScalar>, Table2D<ThermoScalar>, Table2D<ThermoScalar>>(),
-            py::arg("k") = Table2D<ThermoScalar>{},
-            py::arg("kT") = Table2D<ThermoScalar>{},
-            py::arg("kTT") = Table2D<ThermoScalar>{}
+            py::init<MatrixXd, MatrixXd, MatrixXd>(),
+            py::arg("k") = MatrixXd{},
+            py::arg("kT") = MatrixXd{},
+            py::arg("kTT") = MatrixXd{}
         )
         .def_readwrite("k", &CubicEOS::InteractionParamsResult::k)
         .def_readwrite("kT", &CubicEOS::InteractionParamsResult::kT)

--- a/tests/test_cubiceos.py
+++ b/tests/test_cubiceos.py
@@ -1,4 +1,3 @@
-import numpy as np
 from numpy.testing import assert_array_equal
 
 from reaktoro import (
@@ -9,7 +8,6 @@ from reaktoro import (
     EquilibriumSolver,
     BinaryInteractionParams,
     CubicEOSParams,
-    ThermoScalar
 )
 
 
@@ -66,30 +64,30 @@ def test_bips_setup():
     """
     Test the BIPs storage in a BinaryInteractionParams object.
     """
-    k_00 = k_11 = k_22 = ThermoScalar(0.0)
-    k_01 = k_10 = ThermoScalar(0.01)
-    k_02 = k_20 = ThermoScalar(0.50)
-    k_12 = k_21 = ThermoScalar(0.40)
+    k_00 = k_11 = k_22 = 0.0
+    k_01 = k_10 = 0.01
+    k_02 = k_20 = 0.50
+    k_12 = k_21 = 0.40
     k = [
         [k_00, k_01, k_02],
         [k_10, k_11, k_12],
         [k_20, k_21, k_22]
     ]
 
-    kT_00 = kT_11 = kT_22 = ThermoScalar(0.0)
-    kT_01 = kT_10 = ThermoScalar(0.0)
-    kT_02 = kT_20 = ThermoScalar(0.0)
-    kT_12 = kT_21 = ThermoScalar(0.0)
+    kT_00 = kT_11 = kT_22 = 0.0
+    kT_01 = kT_10 = 0.0
+    kT_02 = kT_20 = 0.0
+    kT_12 = kT_21 = 0.0
     kT = [
         [kT_00, kT_01, kT_02],
         [kT_10, kT_11, kT_12],
         [kT_20, kT_21, kT_22]
     ]
 
-    kTT_00 = kTT_11 = kTT_22 = ThermoScalar(0.0)
-    kTT_01 = kTT_10 = ThermoScalar(0.0)
-    kTT_02 = kTT_20 = ThermoScalar(0.0)
-    kTT_12 = kTT_21 = ThermoScalar(0.0)
+    kTT_00 = kTT_11 = kTT_22 = 0.0
+    kTT_01 = kTT_10 = 0.0
+    kTT_02 = kTT_20 = 0.0
+    kTT_12 = kTT_21 = 0.0
     kTT = [
         [kTT_00, kTT_01, kTT_02],
         [kTT_10, kTT_11, kTT_12],
@@ -98,34 +96,9 @@ def test_bips_setup():
 
     bips = BinaryInteractionParams(k, kT, kTT)
 
-    k_expected = np.array([
-        [k_00.val, k_01.val, k_02.val],
-        [k_10.val, k_11.val, k_12.val],
-        [k_20.val, k_21.val, k_22.val]
-    ])
-
-    kT_expected = np.array([
-        [kT_00.val, kT_01.val, kT_02.val],
-        [kT_10.val, kT_11.val, kT_12.val],
-        [kT_20.val, kT_21.val, kT_22.val]
-    ])
-
-    kTT_expected = np.array([
-        [kTT_00.val, kTT_01.val, kTT_02.val],
-        [kTT_10.val, kTT_11.val, kTT_12.val],
-        [kTT_20.val, kTT_21.val, kTT_22.val]
-    ])
-
-    bips_k = np.array(bips.k)
-    bips_kT = np.array(bips.kT)
-    bips_kTT = np.array(bips.kTT)
-
-    nspecies = bips_k.shape[0]
-    for i in range(nspecies):
-        for j in range(nspecies):
-            assert bips_k[i, j].val == k_expected[i, j]
-            assert bips_kT[i, j].val == kT_expected[i, j]
-            assert bips_kTT[i, j].val == kTT_expected[i, j]
+    assert_array_equal(bips.k, k)
+    assert_array_equal(bips.kT, kT)
+    assert_array_equal(bips.kTT, kTT)
 
 
 def test_bips_calculation_function():
@@ -135,30 +108,30 @@ def test_bips_calculation_function():
     temperature.
     """
     def bips_function(T):
-        k_00 = k_11 = k_22 = ThermoScalar(0.0 * T.val)
-        k_01 = k_10 = ThermoScalar(0.01 * T.val)
-        k_02 = k_20 = ThermoScalar(0.50 * T.val)
-        k_12 = k_21 = ThermoScalar(0.40 * T.val)
+        k_00 = k_11 = k_22 = 0.0 * T
+        k_01 = k_10 = 0.01 * T
+        k_02 = k_20 = 0.50 * T
+        k_12 = k_21 = 0.40 * T
         k = [
             [k_00, k_01, k_02],
             [k_10, k_11, k_12],
             [k_20, k_21, k_22]
         ]
 
-        kT_00 = kT_11 = kT_22 = ThermoScalar(0.0)
-        kT_01 = kT_10 = ThermoScalar(0.01)
-        kT_02 = kT_20 = ThermoScalar(0.50)
-        kT_12 = kT_21 = ThermoScalar(0.40)
+        kT_00 = kT_11 = kT_22 = 0.0
+        kT_01 = kT_10 = 0.01
+        kT_02 = kT_20 = 0.50
+        kT_12 = kT_21 = 0.40
         kT = [
             [kT_00, kT_01, kT_02],
             [kT_10, kT_11, kT_12],
             [kT_20, kT_21, kT_22]
         ]
 
-        kTT_00 = kTT_11 = kTT_22 = ThermoScalar(0.0)
-        kTT_01 = kTT_10 = ThermoScalar(0.0)
-        kTT_02 = kTT_20 = ThermoScalar(0.0)
-        kTT_12 = kTT_21 = ThermoScalar(0.0)
+        kTT_00 = kTT_11 = kTT_22 = 0.0
+        kTT_01 = kTT_10 = 0.0
+        kTT_02 = kTT_20 = 0.0
+        kTT_12 = kTT_21 = 0.0
         kTT = [
             [kTT_00, kTT_01, kTT_02],
             [kTT_10, kTT_11, kTT_12],
@@ -168,26 +141,14 @@ def test_bips_calculation_function():
         return bips_values
 
     T_dummy = 2.0
-    T = ThermoScalar(T_dummy)
-    bips_expected = bips_function(T)
+    bips_expected = bips_function(T_dummy)
 
     cubic_eos_params = CubicEOSParams(binary_interaction_values=bips_function)
-    bips_calculated = cubic_eos_params.binary_interaction_values(T)
+    bips_calculated = cubic_eos_params.binary_interaction_values(T_dummy)
 
-    bips_k_calculated = np.array(bips_calculated.k)
-    bips_kT_calculated = np.array(bips_calculated.kT)
-    bips_kTT_calculated = np.array(bips_calculated.kTT)
-
-    bips_k_expected = np.array(bips_expected.k)
-    bips_kT_expected = np.array(bips_expected.kT)
-    bips_kTT_expected = np.array(bips_expected.kTT)
-
-    nspecies = bips_k_calculated.shape[0]
-    for i in range(nspecies):
-        for j in range(nspecies):
-            assert bips_k_calculated[i, j].val == bips_k_expected[i, j].val
-            assert bips_kT_calculated[i, j].val == bips_kT_expected[i, j].val
-            assert bips_kTT_calculated[i, j].val == bips_kTT_expected[i, j].val
+    assert_array_equal(bips_calculated.k, bips_expected.k)
+    assert_array_equal(bips_calculated.kT, bips_expected.kT)
+    assert_array_equal(bips_calculated.kTT, bips_expected.kTT)
 
 
 def test_bips_setup_without_derivatives():
@@ -197,10 +158,10 @@ def test_bips_setup_without_derivatives():
     should be defined.
     """
     def bips_function(T):
-        k_00 = k_11 = k_22 = ThermoScalar(0.0)
-        k_01 = k_10 = ThermoScalar(0.01)
-        k_02 = k_20 = ThermoScalar(0.50)
-        k_12 = k_21 = ThermoScalar(0.40)
+        k_00 = k_11 = k_22 = 0.0
+        k_01 = k_10 = 0.01
+        k_02 = k_20 = 0.50
+        k_12 = k_21 = 0.40
         k = [
             [k_00, k_01, k_02],
             [k_10, k_11, k_12],
@@ -210,20 +171,11 @@ def test_bips_setup_without_derivatives():
         return bips_values
 
     T_dummy = 2.0
-    T = ThermoScalar(T_dummy)
-    bips_expected = bips_function(T)
+    bips_expected = bips_function(T_dummy)
 
     cubic_eos_params = CubicEOSParams(binary_interaction_values=bips_function)
-    bips_calculated = cubic_eos_params.binary_interaction_values(T)
+    bips_calculated = cubic_eos_params.binary_interaction_values(T_dummy)
 
-    bips_k_calculated = np.array(bips_calculated.k)
-
-    bips_k_expected = np.array(bips_expected.k)
-
-    nspecies = bips_k_calculated.shape[0]
-    for i in range(nspecies):
-        for j in range(nspecies):
-            assert bips_k_calculated[i, j].val == bips_k_expected[i, j].val
-    
+    assert_array_equal(bips_calculated.k, bips_expected.k)    
     assert len(bips_calculated.kT) == 0
     assert len(bips_calculated.kTT) == 0

--- a/tests/test_oil_equilibrium.py
+++ b/tests/test_oil_equilibrium.py
@@ -56,7 +56,7 @@ def test_ternary_c1_c4_c10_bips_setup():
     editor.addLiquidPhase(oil_species).setChemicalModelCubicEOS(eos_params)
 
     def calculate_bips(T):
-        zero = reaktoro.ThermoScalar(0.0)
+        zero = 0.0
         k = [
             [zero, zero, zero],
             [zero, zero, zero],
@@ -136,7 +136,7 @@ def test_error_bips_setup():
     """
     The goal of this test is to check a BIP input with incompatible dimensions.
     The BIPs compose a symmetric matrix of size (n_species, n_species). This test checks
-    for the case where one of the rows of the BIP matrix has an incompatible dimension.
+    for the case where the k BIPs matrix is not symmetric.
     """
     db = reaktoro.Database(str(get_test_data_dir() / 'hydrocarbons.xml'))
 
@@ -145,12 +145,12 @@ def test_error_bips_setup():
     gaseous_species = ["C1(g)", "C4(g)", "C10(g)"]
 
     def calculate_bips(T):
-        zero = reaktoro.ThermoScalar(0.0)
+        one = 1.0
         # Wrong BIP matrix
         k = [
-            [zero, zero, zero],
-            [zero, zero, zero],
-            [zero, zero]
+            [one, one, one],
+            [one, one, one],
+            [-one, one, one],
         ]
         bips = reaktoro.BinaryInteractionParams(k)
         return bips
@@ -280,8 +280,8 @@ def test_equilibrium_CH4_CO2_pedersen():
     editor = reaktoro.ChemicalEditor(db)
 
     def calculate_bips(T):
-        k_00 = k_11 = reaktoro.ThermoScalar(0.0)
-        k_01 = k_10 = reaktoro.ThermoScalar(0.12)
+        k_00 = k_11 = 0.0
+        k_01 = k_10 = 0.12
         k = [
             [k_00, k_01],
             [k_10, k_11],

--- a/tests/test_oil_equilibrium.py
+++ b/tests/test_oil_equilibrium.py
@@ -160,7 +160,7 @@ def test_error_bips_setup():
         phase_identification_method=reaktoro.PhaseIdentificationMethod.GibbsEnergyAndEquationOfStateMethod,
         binary_interaction_values=calculate_bips
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='k is not symmetric'):
         editor_bips.addGaseousPhase(gaseous_species).setChemicalModelCubicEOS(eos_params_bips)
 
 


### PR DESCRIPTION
The first version of the BIPs interface is based on the usage of `ThermoScalar` in the construction and definition of the BIPs matrices. This PR changes to use an interface in Python that can handle with `List`s and `numpy.ndarray` directly, contributing to a better usability.

Additionally, the sanity checker for BIPs input has improved.