### PR TITLE
Add publish step to Linux GH Actions workflow

### DIFF
--- a/.dependencies/python.devenv.yml
+++ b/.dependencies/python.devenv.yml
@@ -7,4 +7,4 @@ dependencies:
   - tabulate
   - colorama
   - python={{ python_version }}
-  - twine
+  - setuptools<49.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
           pytest . -n auto
 
       - name: Publish Reaktoro to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,4 +85,3 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: artifacts/python/dist
-          skip_existing: true  # to guarantee that we are uploading a new version

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,10 +78,10 @@ jobs:
           source activate reaktoro
           pytest . -n auto
 
-      - name: Publish Reaktoro to PyPI
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: artifacts/python/dist
+      # - name: Publish Reaktoro to PyPI
+      #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      #     packages_dir: artifacts/python/dist

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,3 +77,11 @@ jobs:
         run: |
           source activate reaktoro
           pytest . -n auto
+
+      - name: Publish Reaktoro to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: artifacts/python/dist

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,3 +85,4 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: artifacts/python/dist
+          skip_existing: true  # to guarantee that we are uploading a new version

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,88 @@
+name: PyPI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+  pull_request:
+
+  schedule:
+    - cron: "0 5 * * 1"  # runs at 05:00 UTC on Mondays
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    env:
+      REAKTORO_USE_OPENLIBM: 1
+      NUMBER_OF_COMPILATION_JOBS: 2
+
+    strategy:
+      fail-fast: true
+      max-parallel: 4
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Configuring Cache
+        id: cache
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache and rebuild the env during the PR
+          CACHE_NUMBER: 1
+        with:
+          path: |
+            **/build
+            **/ccache
+            ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ github.ref }}-${{ env.CACHE_NUMBER }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+
+      - name: Configuring Conda Environment
+        shell: bash -l {0}
+        env:
+          PY_VER: 3.7
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda install conda-devenv
+          conda devenv
+
+      - name: Building and Installing Reaktoro
+        shell: bash -l {0}
+        env:
+          CC: ccache
+          CXX: ccache
+        run: |
+          source activate reaktoro
+          ccache -s
+          ccache -z
+          inv -e compile -n ${{ env.NUMBER_OF_COMPILATION_JOBS }}
+          ccache -s
+          python ci/check_compiled_files.py
+
+      - name: Testing Reaktoro
+        shell: bash -l {0}
+        run: |
+          source activate reaktoro
+          pytest . -n auto
+
+      - name: Publish Reaktoro to PyPI
+        # if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          packages_dir: artifacts/python/dist
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true

--- a/python/reaktoro/CMakeLists.txt
+++ b/python/reaktoro/CMakeLists.txt
@@ -58,7 +58,7 @@ install(CODE
 
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -m pip
-            install reaktoro --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
+            install reaktoro3 --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
             --find-links=\${REAKTORO_PYTHON_DIST_DIR_NATIVE}
         WORKING_DIRECTORY ${REAKTORO_PYTHON_INSTALL_PREFIX})
 "

--- a/python/reaktoro/setup.py.in
+++ b/python/reaktoro/setup.py.in
@@ -14,8 +14,9 @@ with open(readme_filepath, "r") as fh:
 
 requirements = ["numpy", "pandas"]
 
-setup(name='reaktoro',
-      version='${PROJECT_VERSION}',
+setup(name='reaktoro3',
+      # version='${PROJECT_VERSION}',
+      version=0.0.3,
       description='The Python interface of the Reaktoro library.',
       classifiers=[
             "Topic :: Scientific/Engineering",

--- a/python/reaktoro/setup.py.in
+++ b/python/reaktoro/setup.py.in
@@ -16,7 +16,7 @@ requirements = ["numpy", "pandas"]
 
 setup(name='reaktoro3',
       # version='${PROJECT_VERSION}',
-      version=0.0.3,
+      version='0.0.3',
       description='The Python interface of the Reaktoro library.',
       classifiers=[
             "Topic :: Scientific/Engineering",


### PR DESCRIPTION
This PR adds a step in the Linux GH Action that upload Reaktoro to PyPI automatically whenever a commit with a tag is pushed to master.