### PR TITLE
Set pypi publish job (with correct branch name)

### DIFF
--- a/.dependencies/python.devenv.yml
+++ b/.dependencies/python.devenv.yml
@@ -7,4 +7,4 @@ dependencies:
   - tabulate
   - colorama
   - python={{ python_version }}
-  - twine
+  - setuptools<49.0

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,11 @@
-name: linux
+name: PyPI
 
 on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
   pull_request:
 
@@ -11,7 +13,7 @@ on:
     - cron: "0 5 * * 1"  # runs at 05:00 UTC on Mondays
 
 jobs:
-  build:
+  publish:
 
     runs-on: ubuntu-latest
 
@@ -22,8 +24,6 @@ jobs:
     strategy:
       fail-fast: true
       max-parallel: 4
-      matrix:
-        PY_VER: [3.6, 3.7]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
             **/ccache
             ~/conda_pkgs_dir
           key:
-            ${{ runner.os }}-${{ matrix.PY_VER }}-${{ github.ref }}-${{ env.CACHE_NUMBER }}
+            ${{ runner.os }}-${{ github.ref }}-${{ env.CACHE_NUMBER }}
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Configuring Conda Environment
         shell: bash -l {0}
         env:
-          PY_VER: ${{ matrix.PY_VER }}
+          PY_VER: 3.7
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda config --add channels conda-forge
@@ -61,7 +61,6 @@ jobs:
       - name: Building and Installing Reaktoro
         shell: bash -l {0}
         env:
-          PY_VER: ${{ matrix.PY_VER }}
           CC: ccache
           CXX: ccache
         run: |
@@ -78,10 +77,12 @@ jobs:
           source activate reaktoro
           pytest . -n auto
 
-      # - name: Publish Reaktoro to PyPI
-      #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && ${{ matrix.PY_VER }} == '3.7'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
-      #     packages_dir: artifacts/python/dist
+      - name: Publish Reaktoro to PyPI
+        # if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          packages_dir: artifacts/python/dist
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true

--- a/python/reaktoro/CMakeLists.txt
+++ b/python/reaktoro/CMakeLists.txt
@@ -58,7 +58,7 @@ install(CODE
 
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -m pip
-            install reaktoro --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
+            install reaktoro3 --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
             --find-links=\${REAKTORO_PYTHON_DIST_DIR_NATIVE}
         WORKING_DIRECTORY ${REAKTORO_PYTHON_INSTALL_PREFIX})
 "

--- a/python/reaktoro/setup.py.in
+++ b/python/reaktoro/setup.py.in
@@ -14,8 +14,9 @@ with open(readme_filepath, "r") as fh:
 
 requirements = ["numpy", "pandas"]
 
-setup(name='reaktoro',
-      version='${PROJECT_VERSION}',
+setup(name='reaktoro3',
+      # version='${PROJECT_VERSION}',
+      version='0.0.3',
       description='The Python interface of the Reaktoro library.',
       classifiers=[
             "Topic :: Scientific/Engineering",


### PR DESCRIPTION
* Add GH Action publish step to linux workflow

* Set skip_existing as True in the PyPI publish step

* Remove flag for duplicated pypi upload

It is better to explicitly keep track of duplicated uploads, since this is a mistake

* Add small fix to pypi publish step if condition

* Add separated pypi publish workflow

* Comment pypi publish step in linux.yml

* Restrict setuptools<49.0 version

* Try to publish Reaktoro in TestPyPI

* Fix version in setup.py