### PR TITLE
Add additional flags to Reaktoro's pip install

### DIFF
--- a/python/reaktoro/CMakeLists.txt
+++ b/python/reaktoro/CMakeLists.txt
@@ -21,7 +21,7 @@ add_custom_target(reaktoro ALL
     COMMAND ${PYTHON_EXECUTABLE} -m pip install
         reaktoro --prefix=${CMAKE_BINARY_DIR}
         --find-links=${CMAKE_CURRENT_BINARY_DIR}/dist
-        --no-index
+        --no-index --no-deps --no-cache-dir
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # Set dependencies of reaktoro target
@@ -66,7 +66,7 @@ install(CODE
         COMMAND ${PYTHON_EXECUTABLE} -m pip
             install reaktoro --prefix=\${REAKTORO_PYTHON_INSTALL_PREFIX_NATIVE}
             --find-links=\${REAKTORO_PYTHON_DIST_DIR_NATIVE}
-            --no-index
+	    --no-index --no-deps --no-cache-dir
         WORKING_DIRECTORY ${REAKTORO_PYTHON_INSTALL_PREFIX})
 "
 )


### PR DESCRIPTION
This PR introduces a small modification in the Reaktoro build and installation. The checks for deps when installing Reaktoro's Python wheels are not necessary since it is performed inside conda envs.