### PR TITLE
Move molar_surface_area to inside a lambda function

### DIFF
--- a/Reaktoro/Thermodynamics/Reactions/MineralReaction.cpp
+++ b/Reaktoro/Thermodynamics/Reactions/MineralReaction.cpp
@@ -489,14 +489,11 @@ auto createReaction(const MineralReaction& mineralrxn, const ChemicalSystem& sys
     }
     else
     {
-        // The molar surface area of the mineral
-        const double molar_surface_area = molarSurfaceArea(mineralrxn, system);
-
-        // The surface area of the mineral
-        const double surface_area = mineralrxn.surfaceArea();
-
         rate = [=](const ChemicalProperties& properties) mutable
         {
+            // The molar surface area of the mineral
+            const double molar_surface_area = molarSurfaceArea(mineralrxn, system);
+
             // The composition of the chemical system
             const auto n = properties.composition();
 


### PR DESCRIPTION
This is a necessary change in order to propagate the changes to `Reaktoro::KineticSolver` through MineralReaction in Reactive Transport problems considering kinetics and updating -- for instance, due to dissolution -- the specific surface area (accessed and modified through a `Reaktoro::MineralReaction` `std::shared_ptr`).

CC: @tadeu 