### PR TITLE
Extension of ion exchange modelling by Davies or Debye-Huckel activity coefficients

### DIFF
--- a/Reaktoro/Common/ParseUtils.cpp
+++ b/Reaktoro/Common/ParseUtils.cpp
@@ -19,7 +19,6 @@
 
 // Reaktoro includes
 #include <Reaktoro/Common/Algorithms.hpp>
-#include <Reaktoro/Common/Exception.hpp>
 #include <Reaktoro/Common/NamingUtils.hpp>
 #include <Reaktoro/Common/StringUtils.hpp>
 

--- a/Reaktoro/Core/ActivityProps.hpp
+++ b/Reaktoro/Core/ActivityProps.hpp
@@ -128,12 +128,12 @@ struct ActivityPropsBase
 };
 
 /// The activity and excess thermodynamic properties of a phase.
-using ActivityProps = ActivityPropsBase<real, ArrayXr, Vec<Any>>;
+using ActivityProps = ActivityPropsBase<real, ArrayXr, Map<String, Any>>;
 
 /// The non-const view to the activity and excess thermodynamic properties of a phase.
-using ActivityPropsRef = ActivityPropsBase<real&, ArrayXrRef, Vec<Any>&>;
+using ActivityPropsRef = ActivityPropsBase<real&, ArrayXrRef, Map<String, Any>&>;
 
 /// The const view to the activity and excess thermodynamic properties of a phase.
-using ActivityPropsConstRef = ActivityPropsBase<const real&, ArrayXrConstRef, const Vec<Any>&>;
+using ActivityPropsConstRef = ActivityPropsBase<const real&, ArrayXrConstRef, const Map<String, Any>&>;
 
 } // namespace Reaktoro

--- a/Reaktoro/Core/ActivityProps.py.cxx
+++ b/Reaktoro/Core/ActivityProps.py.cxx
@@ -40,7 +40,7 @@ void exportActivityProps(py::module& m)
         ;
 
     #define get(field) [](const ActivityPropsRef& self) { return self.field; }
-    #define set(field) [](ActivityPropsRef& self, const decltype(ActivityPropsRef::field)& val) { self.field = val; }
+    #define set(field) [](ActivityPropsRef& self, decltype(ActivityPropsRef::field)& val) { self.field = val; }
 
     py::class_<ActivityPropsRef>(m, "ActivityPropsRef")
         .def_property("Vex", get(Vex), set(Vex))

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -29,7 +29,6 @@ using namespace tabulate;
 #include <Reaktoro/Core/ChemicalPropsPhase.hpp>
 #include <Reaktoro/Core/ChemicalState.hpp>
 #include <Reaktoro/Core/Utils.hpp>
-#include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
 
 namespace Reaktoro {
 

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -88,8 +88,6 @@ auto ChemicalProps::update(const real& T, const real& P, ArrayXrConstRef n) -> v
         const auto np = n.segment(offset, size);
         if(msystem.phase(i).name() == "AqueousPhase")
         {
-            // TODO: leave the evaluation of only one extra data entrance
-            m_extra["AqueousProps"] = AqueousProps(*this);
             m_extra["AqueousMixtureState"] = AqueousMixture(msystem.phase(i).species()).state(T, P, np/np.sum());
         }
         phaseProps(i).update(T, P, np, m_extra);

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -85,10 +85,6 @@ auto ChemicalProps::update(const real& T, const real& P, ArrayXrConstRef n) -> v
     {
         const auto size = msystem.phase(i).species().size();
         const auto np = n.segment(offset, size);
-        if(msystem.phase(i).name() == "AqueousPhase")
-        {
-            m_extra["AqueousMixtureState"] = AqueousMixture(msystem.phase(i).species()).state(T, P, np/np.sum());
-        }
         phaseProps(i).update(T, P, np, m_extra);
         offset += size;
     }
@@ -122,7 +118,7 @@ auto ChemicalProps::updateIdeal(const real& T, const real& P, ArrayXrConstRef n)
     {
         const auto size = msystem.phase(i).species().size();
         const auto np = n.segment(offset, size);
-        phaseProps(i).updateIdeal(T, P, np);
+        phaseProps(i).updateIdeal(T, P, np, m_extra);
         offset += size;
     }
 }

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -29,6 +29,8 @@ using namespace tabulate;
 #include <Reaktoro/Core/ChemicalPropsPhase.hpp>
 #include <Reaktoro/Core/ChemicalState.hpp>
 #include <Reaktoro/Core/Utils.hpp>
+#include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
+#include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
 
 namespace Reaktoro {
 
@@ -84,6 +86,12 @@ auto ChemicalProps::update(const real& T, const real& P, ArrayXrConstRef n) -> v
     {
         const auto size = msystem.phase(i).species().size();
         const auto np = n.segment(offset, size);
+        if(msystem.phase(i).name() == "AqueousPhase")
+        {
+            // TODO: leave the evaluation of only one extra data entrance
+            m_extra["AqueousProps"] = AqueousProps(*this);
+            m_extra["AqueousMixtureState"] = AqueousMixture(msystem.phase(i).species()).state(T, P, np/np.sum());
+        }
         phaseProps(i).update(T, P, np, m_extra);
         offset += size;
     }

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -84,7 +84,7 @@ auto ChemicalProps::update(const real& T, const real& P, ArrayXrConstRef n) -> v
     {
         const auto size = msystem.phase(i).species().size();
         const auto np = n.segment(offset, size);
-        phaseProps(i).update(T, P, np);
+        phaseProps(i).update(T, P, np, m_extra);
         offset += size;
     }
 }

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -29,7 +29,6 @@ using namespace tabulate;
 #include <Reaktoro/Core/ChemicalPropsPhase.hpp>
 #include <Reaktoro/Core/ChemicalState.hpp>
 #include <Reaktoro/Core/Utils.hpp>
-#include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
 
 namespace Reaktoro {

--- a/Reaktoro/Core/ChemicalProps.hpp
+++ b/Reaktoro/Core/ChemicalProps.hpp
@@ -385,6 +385,9 @@ private:
 
     /// The chemical potentials of the species in the system.
     ArrayXr u;
+
+    /// The extra data mapped to activity model of particular phase that may be reused by subsequent phases.
+    Map<String, Any> m_extra;
 };
 
 /// Output a ChemicalProps object to an output stream.

--- a/Reaktoro/Core/ChemicalPropsPhase.hpp
+++ b/Reaktoro/Core/ChemicalPropsPhase.hpp
@@ -195,20 +195,11 @@ public:
     : mphase(other.mphase), mdata(other.mdata)
     {}
 
-//    /// Update the chemical properties of the phase.
-//    /// @param T The temperature condition (in K)
-//    /// @param P The pressure condition (in Pa)
-//    /// @param n The amounts of the species in the phase (in mol)
-//    auto update(const real& T, const real& P, ArrayXrConstRef n)
-//    {
-//        _update<false>(T, P, n);
-//    }
-
     /// Update the chemical properties of the phase.
     /// @param T The temperature condition (in K)
     /// @param P The pressure condition (in Pa)
     /// @param n The amounts of the species in the phase (in mol)
-    /// @param extra The extra data mapped to activity mode
+    /// @param extra The extra properties evaluated in the activity models
     auto update(const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
     {
         _update<false>(T, P, n, extra);
@@ -224,7 +215,7 @@ public:
     /// @param T The temperature condition (in K)
     /// @param P The pressure condition (in Pa)
     /// @param n The amounts of the species in the phase (in mol)
-    /// @param extra The extra data mapped to activity mode
+    /// @param extra The extra properties evaluated in the activity models
     auto updateIdeal(const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
     {
         _update<true>(T, P, n, extra);
@@ -469,85 +460,6 @@ private:
     ChemicalPropsPhaseBaseData<Real, Array> mdata;
 
 private:
-//    /// Update the chemical properties of the phase.
-//    /// @param T The temperature condition (in K)
-//    /// @param P The pressure condition (in Pa)
-//    /// @param n The amounts of the species in the phase (in mol)
-//    template<bool use_ideal_activity_model>
-//    auto _update(const real& T, const real& P, ArrayXrConstRef n)
-//    {
-//        mdata.T = T;
-//        mdata.P = P;
-//        mdata.n = n;
-//
-//        const auto R = universalGasConstant;
-//
-//        auto& nsum = mdata.nsum;
-//        auto& x    = mdata.x;
-//        auto& G0   = mdata.G0;
-//        auto& H0   = mdata.H0;
-//        auto& V0   = mdata.V0;
-//        auto& Cp0  = mdata.Cp0;
-//        auto& Cv0  = mdata.Cv0;
-//        auto& Vex  = mdata.Vex;
-//        auto& VexT = mdata.VexT;
-//        auto& VexP = mdata.VexP;
-//        auto& Gex  = mdata.Gex;
-//        auto& Hex  = mdata.Hex;
-//        auto& Cpex = mdata.Cpex;
-//        auto& Cvex = mdata.Cvex;
-//        auto& ln_g = mdata.ln_g;
-//        auto& ln_a = mdata.ln_a;
-//        auto& u    = mdata.u;
-//
-//        const auto& species = phase().species();
-//        const auto N = species.size();
-//
-//        assert(    n.size() == N );
-//        assert(   G0.size() == N );
-//        assert(   H0.size() == N );
-//        assert(   V0.size() == N );
-//        assert(  Cp0.size() == N );
-//        assert(  Cv0.size() == N );
-//        assert( ln_g.size() == N );
-//        assert( ln_a.size() == N );
-//        assert(    u.size() == N );
-//
-//        // Compute the standard thermodynamic properties of the species in the phase.
-//        StandardThermoProps aux;
-//        for(auto i = 0; i < N; ++i)
-//        {
-//            aux = species[i].props(T, P);
-//            G0[i]  = aux.G0;
-//            H0[i]  = aux.H0;
-//            V0[i]  = aux.V0;
-//            Cp0[i] = aux.Cp0;
-//            Cv0[i] = aux.Cv0;
-//        }
-//
-//        // Compute the activity properties of the phase.
-//        nsum = n.sum();
-//
-//        if(nsum == 0.0)
-//            x = (N == 1) ? 1.0 : 0.0;
-//        else x = n / nsum;
-//
-//        // Ensure there are no zero mole fractions
-//        error(x.minCoeff() == 0.0, "Could not compute the chemical properties of phase ",
-//            phase().name(), " because it has one or more species with zero amounts.");
-//
-//        Map<String, Any> extra;
-//        ActivityPropsRef aprops{ Vex, VexT, VexP, Gex, Hex, Cpex, Cvex, ln_g, ln_a, extra};
-//        ActivityArgs args{ T, P, x };
-//        const ActivityModel& activity_model = use_ideal_activity_model ?  // IMPORTANT: Use `const ActivityModel&` here instead of `ActivityModel`, otherwise a new model is constructed without cache, and so memoization will not take effect.
-//            phase().idealActivityModel() : phase().activityModel();
-//
-//        if(nsum == 0.0) aprops = 0.0;
-//        else activity_model(aprops, args);
-//
-//        // Compute the chemical potentials of the species
-//        u = G0 + R*T*ln_a;
-//    }
 
     /// Update the chemical properties of the phase.
     /// @param T The temperature condition (in K)
@@ -560,7 +472,6 @@ private:
         mdata.T = T;
         mdata.P = P;
         mdata.n = n;
-        //m_extra = extra;
 
         const auto R = universalGasConstant;
 

--- a/Reaktoro/Core/ChemicalPropsPhase.hpp
+++ b/Reaktoro/Core/ChemicalPropsPhase.hpp
@@ -443,12 +443,6 @@ public:
         return molarHelmholtzEnergy() * amount();
     }
 
-//    /// Return the extra data mapped to activity model of particular phase that may be reused by subsequent phases.
-//    auto extra() const -> Map<String, Any>
-//    {
-//        return m_extra;
-//    }
-
     /// Assign the given array data to this ChemicalPropsPhaseBase object.
     auto operator=(const ArrayStream<Real>& array)
     {
@@ -469,9 +463,6 @@ public:
 private:
     /// The phase associated with these primary chemical properties.
     Phase mphase;
-
-//    /// The extra data mapped to activity model of particular phase that may be reused by subsequent phases.
-//    Map<String, Any> m_extra;
 
     /// The primary chemical property data of the phase from which others are calculated.
     ChemicalPropsPhaseBaseData<Real, Array> mdata;

--- a/Reaktoro/Core/ChemicalPropsPhase.hpp
+++ b/Reaktoro/Core/ChemicalPropsPhase.hpp
@@ -205,6 +205,16 @@ public:
     }
 
     /// Update the chemical properties of the phase.
+    /// @param T The temperature condition (in K)
+    /// @param P The pressure condition (in Pa)
+    /// @param n The amounts of the species in the phase (in mol)
+    /// @param extra The extra data mapped to activity mode
+    auto update(const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
+    {
+        _update<false>(T, P, n, extra);
+    }
+
+    /// Update the chemical properties of the phase.
     auto update(const ChemicalPropsPhaseBaseData<Real, Array>& data)
     {
         mdata = data;
@@ -433,6 +443,12 @@ public:
         return molarHelmholtzEnergy() * amount();
     }
 
+//    /// Return the extra data mapped to activity model of particular phase that may be reused by subsequent phases.
+//    auto extra() const -> Map<String, Any>
+//    {
+//        return m_extra;
+//    }
+
     /// Assign the given array data to this ChemicalPropsPhaseBase object.
     auto operator=(const ArrayStream<Real>& array)
     {
@@ -453,6 +469,9 @@ public:
 private:
     /// The phase associated with these primary chemical properties.
     Phase mphase;
+
+//    /// The extra data mapped to activity model of particular phase that may be reused by subsequent phases.
+//    Map<String, Any> m_extra;
 
     /// The primary chemical property data of the phase from which others are calculated.
     ChemicalPropsPhaseBaseData<Real, Array> mdata;
@@ -525,11 +544,92 @@ private:
         error(x.minCoeff() == 0.0, "Could not compute the chemical properties of phase ",
             phase().name(), " because it has one or more species with zero amounts.");
 
-        Vec<Any> extra;
-        ActivityPropsRef aprops{ Vex, VexT, VexP, Gex, Hex, Cpex, Cvex, ln_g, ln_a, extra };
+        Map<String, Any> extra;
+        ActivityPropsRef aprops{ Vex, VexT, VexP, Gex, Hex, Cpex, Cvex, ln_g, ln_a, extra};
         ActivityArgs args{ T, P, x };
         const ActivityModel& activity_model = use_ideal_activity_model ?  // IMPORTANT: Use `const ActivityModel&` here instead of `ActivityModel`, otherwise a new model is constructed without cache, and so memoization will not take effect.
             phase().idealActivityModel() : phase().activityModel();
+
+        if(nsum == 0.0) aprops = 0.0;
+        else activity_model(aprops, args);
+
+        // Compute the chemical potentials of the species
+        u = G0 + R*T*ln_a;
+    }
+
+    /// Update the chemical properties of the phase.
+    /// @param T The temperature condition (in K)
+    /// @param P The pressure condition (in Pa)
+    /// @param n The amounts of the species in the phase (in mol)
+    /// @param extra The extra data mapped to activity mode
+    template<bool use_ideal_activity_model>
+    auto _update(const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
+    {
+        mdata.T = T;
+        mdata.P = P;
+        mdata.n = n;
+        //m_extra = extra;
+
+        const auto R = universalGasConstant;
+
+        auto& nsum = mdata.nsum;
+        auto& x    = mdata.x;
+        auto& G0   = mdata.G0;
+        auto& H0   = mdata.H0;
+        auto& V0   = mdata.V0;
+        auto& Cp0  = mdata.Cp0;
+        auto& Cv0  = mdata.Cv0;
+        auto& Vex  = mdata.Vex;
+        auto& VexT = mdata.VexT;
+        auto& VexP = mdata.VexP;
+        auto& Gex  = mdata.Gex;
+        auto& Hex  = mdata.Hex;
+        auto& Cpex = mdata.Cpex;
+        auto& Cvex = mdata.Cvex;
+        auto& ln_g = mdata.ln_g;
+        auto& ln_a = mdata.ln_a;
+        auto& u    = mdata.u;
+
+        const auto& species = phase().species();
+        const auto N = species.size();
+
+        assert(    n.size() == N );
+        assert(   G0.size() == N );
+        assert(   H0.size() == N );
+        assert(   V0.size() == N );
+        assert(  Cp0.size() == N );
+        assert(  Cv0.size() == N );
+        assert( ln_g.size() == N );
+        assert( ln_a.size() == N );
+        assert(    u.size() == N );
+
+        // Compute the standard thermodynamic properties of the species in the phase.
+        StandardThermoProps aux;
+        for(auto i = 0; i < N; ++i)
+        {
+            aux = species[i].props(T, P);
+            G0[i]  = aux.G0;
+            H0[i]  = aux.H0;
+            V0[i]  = aux.V0;
+            Cp0[i] = aux.Cp0;
+            Cv0[i] = aux.Cv0;
+        }
+
+        // Compute the activity properties of the phase.
+        nsum = n.sum();
+
+        if(nsum == 0.0)
+            x = (N == 1) ? 1.0 : 0.0;
+        else x = n / nsum;
+
+        // Ensure there are no zero mole fractions
+        error(x.minCoeff() == 0.0, "Could not compute the chemical properties of phase ",
+              phase().name(), " because it has one or more species with zero amounts.");
+
+        ActivityPropsRef aprops{ Vex, VexT, VexP, Gex, Hex, Cpex, Cvex, ln_g, ln_a, extra };
+        ActivityArgs args{ T, P, x };
+        const ActivityModel& activity_model = use_ideal_activity_model ?  // IMPORTANT: Use `const ActivityModel&` here instead of `ActivityModel`, otherwise a new model is constructed without cache, and so memoization will not take effect.
+                phase().idealActivityModel() : phase().activityModel();
 
         if(nsum == 0.0) aprops = 0.0;
         else activity_model(aprops, args);

--- a/Reaktoro/Core/ChemicalPropsPhase.py.cxx
+++ b/Reaktoro/Core/ChemicalPropsPhase.py.cxx
@@ -24,14 +24,14 @@ using namespace Reaktoro;
 
 void exportChemicalPropsPhase(py::module& m)
 {
-    auto update1 = [](ChemicalPropsPhase& self, const real& T, const real& P, ArrayXrConstRef n)
+    auto update1 = [](ChemicalPropsPhase& self, const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
     {
-        self.update(T, P, n);
+        self.update(T, P, n, extra);
     };
 
-    auto updateIdeal1 = [](ChemicalPropsPhase& self, const real& T, const real& P, ArrayXrConstRef n)
+    auto updateIdeal1 = [](ChemicalPropsPhase& self, const real& T, const real& P, ArrayXrConstRef n, Map<String, Any>& extra)
     {
-        self.updateIdeal(T, P, n);
+        self.updateIdeal(T, P, n, extra);
     };
 
     py::class_<ChemicalPropsPhase>(m, "ChemicalPropsPhase")

--- a/Reaktoro/Core/ChemicalPropsPhase.test.cxx
+++ b/Reaktoro/Core/ChemicalPropsPhase.test.cxx
@@ -133,7 +133,9 @@ TEST_CASE("Testing ChemicalPropsPhase class", "[ChemicalPropsPhase]")
         const real Utot = U * nsum;
         const real Atot = A * nsum;
 
-        CHECK_NOTHROW( props.update(T, P, n) );
+        Map<String, Any> extra;
+
+        CHECK_NOTHROW( props.update(T, P, n, extra) );
 
         CHECK( props.temperature() == T );
         CHECK( props.pressure()    == P );
@@ -216,7 +218,7 @@ TEST_CASE("Testing ChemicalPropsPhase class", "[ChemicalPropsPhase]")
         const double Atot_T = A_T * nsum;
 
         autodiff::seed(T);
-        props.update(T, P, n);
+        props.update(T, P, n, extra);
         autodiff::unseed(T);
 
         CHECK( grad(props.temperature()) == 1.0 );
@@ -300,7 +302,7 @@ TEST_CASE("Testing ChemicalPropsPhase class", "[ChemicalPropsPhase]")
         const double Atot_P = A_P * nsum;
 
         autodiff::seed(P);
-        props.update(T, P, n);
+        props.update(T, P, n, extra);
         autodiff::unseed(P);
 
         CHECK( grad(props.temperature()) == 0.0 );
@@ -395,7 +397,7 @@ TEST_CASE("Testing ChemicalPropsPhase class", "[ChemicalPropsPhase]")
         {
             INFO("i = " << i);
             autodiff::seed(n[i]);
-            props.update(T, P, n);
+            props.update(T, P, n, extra);
             autodiff::unseed(n[i]);
 
             CHECK( grad(props.temperature()) == 0.0 );
@@ -442,6 +444,8 @@ TEST_CASE("Testing ChemicalPropsPhase class", "[ChemicalPropsPhase]")
 
         const ArrayXr n = ArrayXr{{ 0.0, 0.0, 0.0, 0.0 }};
 
-        CHECK_THROWS( props.update(T, P, n) );
+        Map<String, Any> extra;
+
+        CHECK_THROWS( props.update(T, P, n, extra) );
     }
 }

--- a/Reaktoro/Core/Phases.hpp
+++ b/Reaktoro/Core/Phases.hpp
@@ -568,25 +568,4 @@ public:
     }
 };
 
-/// The class used to configure an exchanger phase.
-class IonExchangerPhase : public GenericPhase
-{
-public:
-    /// Construct a default IonExchangePhase object.
-    IonExchangerPhase() : GenericPhase() { initialize(); }
-
-    /// Construct an IonExchangePhase object with given species names.
-    explicit IonExchangerPhase(const StringList& species) : GenericPhase(species) { initialize(); }
-
-    /// Initialize the default attributes of this IonExchangePhase object.
-    auto initialize() -> void
-    {
-        setName("IonExchangerPhase");
-        setStateOfMatter(StateOfMatter::Solid);
-        setAggregateState(AggregateState::IonExchange);
-        setActivityModel(ActivityModelIdealSolution());
-        setIdealActivityModel(ActivityModelIdealSolution());
-    }
-};
-
 } // namespace Reaktoro

--- a/Reaktoro/Core/Phases.hpp
+++ b/Reaktoro/Core/Phases.hpp
@@ -27,6 +27,7 @@
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealAqueous.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealGas.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealSolution.hpp>
+#include <Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.hpp>
 
 namespace Reaktoro {
 
@@ -541,6 +542,48 @@ public:
             AggregateState::CrystallineSolid,
             AggregateState::AmorphousSolid
         });
+        setActivityModel(ActivityModelIdealSolution());
+        setIdealActivityModel(ActivityModelIdealSolution());
+    }
+};
+
+/// The class used to configure an ion exchange phase.
+class IonExchangePhase : public GenericPhase
+{
+public:
+    /// Construct a default IonExchangePhase object.
+    IonExchangePhase() : GenericPhase() { initialize(); }
+
+    /// Construct an IonExchangePhase object with given species names.
+    explicit IonExchangePhase(const StringList& species) : GenericPhase(species) { initialize(); }
+
+    /// Initialize the default attributes of this LiquidPhase object.
+    auto initialize() -> void
+    {
+        setName("IonExchangePhase");
+        setStateOfMatter(StateOfMatter::Solid);
+        setAggregateState(AggregateState::IonExchange);
+        setActivityModel(ActivityModelIonExchangeGainesThomas());
+        setIdealActivityModel(ActivityModelIdealSolution());
+    }
+};
+
+/// The class used to configure an exchanger phase.
+class IonExchangerPhase : public GenericPhase
+{
+public:
+    /// Construct a default IonExchangePhase object.
+    IonExchangerPhase() : GenericPhase() { initialize(); }
+
+    /// Construct an IonExchangePhase object with given species names.
+    explicit IonExchangerPhase(const StringList& species) : GenericPhase(species) { initialize(); }
+
+    /// Initialize the default attributes of this LiquidPhase object.
+    auto initialize() -> void
+    {
+        setName("IonExchangerPhase");
+        setStateOfMatter(StateOfMatter::Solid);
+        setAggregateState(AggregateState::IonExchange);
         setActivityModel(ActivityModelIdealSolution());
         setIdealActivityModel(ActivityModelIdealSolution());
     }

--- a/Reaktoro/Core/Phases.hpp
+++ b/Reaktoro/Core/Phases.hpp
@@ -27,7 +27,7 @@
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealAqueous.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealGas.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealSolution.hpp>
-#include <Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.hpp>
+#include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.hpp>
 
 namespace Reaktoro {
 
@@ -42,7 +42,7 @@ struct Speciate
 };
 
 /// The auxiliary function used to specify phase species to be determined from element symbols.
-inline auto speciate(const StringList& symbols) { return Speciate{symbols}; };
+inline auto speciate(const StringList& symbols) { return Speciate{symbols}; }
 
 /// The auxiliary type used to specify species that should be filtered out when contructing a phase.
 struct Exclude
@@ -55,7 +55,7 @@ struct Exclude
 };
 
 /// The auxiliary function used to specify species that should be filtered out when contructing a phase.
-inline auto exclude(const StringList& tags) { return Exclude{tags}; };
+inline auto exclude(const StringList& tags) { return Exclude{tags}; }
 
 /// The base type for all other classes defining more specific phases.
 /// @ingroup Core
@@ -557,14 +557,14 @@ public:
     /// Construct an IonExchangePhase object with given species names.
     explicit IonExchangePhase(const StringList& species) : GenericPhase(species) { initialize(); }
 
-    /// Initialize the default attributes of this LiquidPhase object.
+    /// Initialize the default attributes of this IonExchangePhase object.
     auto initialize() -> void
     {
         setName("IonExchangePhase");
         setStateOfMatter(StateOfMatter::Solid);
         setAggregateState(AggregateState::IonExchange);
-        setActivityModel(ActivityModelIonExchangeGainesThomas());
-        setIdealActivityModel(ActivityModelIdealSolution());
+        setActivityModel(ActivityModelIdealIonExchange());
+        setIdealActivityModel(ActivityModelIdealIonExchange());
     }
 };
 
@@ -578,7 +578,7 @@ public:
     /// Construct an IonExchangePhase object with given species names.
     explicit IonExchangerPhase(const StringList& species) : GenericPhase(species) { initialize(); }
 
-    /// Initialize the default attributes of this LiquidPhase object.
+    /// Initialize the default attributes of this IonExchangePhase object.
     auto initialize() -> void
     {
         setName("IonExchangerPhase");

--- a/Reaktoro/Equilibrium/EquilibriumSolver.test.cxx
+++ b/Reaktoro/Equilibrium/EquilibriumSolver.test.cxx
@@ -80,7 +80,7 @@ TEST_CASE("Testing EquilibriumSolver", "[EquilibriumSolver]")
     EquilibriumOptions options;
     // options.optima.output.active = true;
     options.hessian = GibbsHessian::Exact;
-    options.optima.maxiterations = 100;
+    options.optima.maxiters = 100;
     options.optima.convergence.tolerance = 1e-10;
 
     EquilibriumResult result;

--- a/Reaktoro/Equilibrium/EquilibriumSolver.test.cxx
+++ b/Reaktoro/Equilibrium/EquilibriumSolver.test.cxx
@@ -80,7 +80,7 @@ TEST_CASE("Testing EquilibriumSolver", "[EquilibriumSolver]")
     EquilibriumOptions options;
     // options.optima.output.active = true;
     options.hessian = GibbsHessian::Exact;
-    options.optima.maxiters = 100;
+    options.optima.maxiterations = 100;
     options.optima.convergence.tolerance = 1e-10;
 
     EquilibriumResult result;

--- a/Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.cpp
+++ b/Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.cpp
@@ -25,12 +25,9 @@ CMRC_DECLARE(ReaktoroDatabases);
 // Reaktoro includes
 #include <Reaktoro/Common/Algorithms.hpp>
 #include <Reaktoro/Common/Exception.hpp>
-#include <Reaktoro/Common/Memoization.hpp>
 #include <Reaktoro/Core/FormationReaction.hpp>
 #include <Reaktoro/Extensions/Phreeqc/PhreeqcThermo.hpp>
 #include <Reaktoro/Extensions/Phreeqc/PhreeqcUtils.hpp>
-#include <Reaktoro/Models/ReactionThermoModelPhreeqcLgK.hpp>
-#include <Reaktoro/Models/ReactionThermoModelVantHoff.hpp>
 
 namespace Reaktoro {
 namespace detail {
@@ -163,7 +160,7 @@ struct PhreeqcDatabaseHelper
             errorif(idx >= elements.size(), "Unknown PHREEQC element "
                 "with symbol `", PhreeqcUtils::symbol(element), "` in PHREEQC species "
                 "with name `", PhreeqcUtils::name(s), "`. "
-                "The element may also be invalid (e.g., without molar mass information).");
+                "The element may also be invalid (e.g., without molar mass information).")
             pairs.emplace_back(elements[idx], coeff);
         }
 
@@ -244,7 +241,7 @@ auto getPhreeqcDatabaseContent(String name) -> String
         "");
     auto fs = cmrc::ReaktoroDatabases::get_filesystem();
     auto contents = fs.open("databases/phreeqc/" + name);
-    return String(contents.begin(), contents.end());
+    return String{contents.begin(), contents.end()};
 }
 
 /// Create the Species objects from given PHREEQC database.

--- a/Reaktoro/Thermodynamics.hpp
+++ b/Reaktoro/Thermodynamics.hpp
@@ -47,3 +47,4 @@
 #include <Reaktoro/Thermodynamics/Fluids/ActivityModelSpycherPruessEnnis.hpp>
 #include <Reaktoro/Thermodynamics/Fluids/ActivityModelSpycherReed.hpp>
 #include <Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.hpp>
+#include <Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp>

--- a/Reaktoro/Thermodynamics.hpp
+++ b/Reaktoro/Thermodynamics.hpp
@@ -38,6 +38,7 @@
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealGas.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealSolution.hpp>
 #include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealAqueous.hpp>
+#include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.hpp>
 #include <Reaktoro/Thermodynamics/Solids/ActivityModelVanLaar.hpp>
 #include <Reaktoro/Thermodynamics/Solids/ActivityModelRedlichKister.hpp>
 #include <Reaktoro/Thermodynamics/Fluids/CubicEOS.hpp>

--- a/Reaktoro/Thermodynamics.py.cxx
+++ b/Reaktoro/Thermodynamics.py.cxx
@@ -56,8 +56,10 @@ void exportWaterThermoProps(py::module& m);
 void exportWaterThermoPropsUtils(py::module& m);
 void exportWaterUtils(py::module& m);
 
-// Thermodynamics/Aqueous
+// Thermodynamics/Surface
 void exportActivityModelIonExchange(py::module& m);
+void exportIonExchangeSurface(py::module& m);
+
 
 void exportThermodynamics(py::module& m)
 {
@@ -101,4 +103,5 @@ void exportThermodynamics(py::module& m)
 
     // Thermodynamics/Surface
     exportActivityModelIonExchange(m);
+    exportIonExchangeSurface(m);
 }

--- a/Reaktoro/Thermodynamics.py.cxx
+++ b/Reaktoro/Thermodynamics.py.cxx
@@ -39,6 +39,7 @@ void exportActivityModelSpycherReed(py::module& m);
 void exportActivityModelIdealAqueous(py::module& m);
 void exportActivityModelIdealGas(py::module& m);
 void exportActivityModelIdealSolution(py::module& m);
+void exportActivityModelIdealIonExchange(py::module& m);
 
 // Thermodynamics/Solids
 void exportActivityModelRedlichKister(py::module& m);
@@ -81,6 +82,7 @@ void exportThermodynamics(py::module& m)
     exportActivityModelIdealAqueous(m);
     exportActivityModelIdealGas(m);
     exportActivityModelIdealSolution(m);
+    exportActivityModelIdealIonExchange(m);
 
     // Thermodynamics/Solids
     exportActivityModelRedlichKister(m);

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
@@ -342,7 +342,8 @@ auto activityModelDebyeHuckel(const SpeciesList& species, ActivityModelDebyeHuck
         state = mixture.state(T, P, x);
 
         // Export the aqueous mixture and its state via the `extra` data member
-        props.extra = { mixture, state };
+        props.extra["AqueousMixtureState"] = state;
+        props.extra["AqueousMixture"] = mixture;
 
         // Auxiliary constant references
         const auto& m = state.m;             // the molalities of all species

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
@@ -291,9 +291,6 @@ auto activityModelDebyeHuckel(const SpeciesList& species, ActivityModelDebyeHuck
     // The number of moles of water per kg
     const auto nwo = 1.0/Mw;
 
-    // The number of species in the aqueous mixture
-    const auto num_species = species.size();
-
     // The number of charged and neutral species in the aqueous mixture
     const auto num_charged_species = mixture.charged().size();
     const auto num_neutral_species = mixture.neutral().size();

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDrummond.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDrummond.cpp
@@ -39,8 +39,7 @@ auto ActivityModelDrummond(String gas, ActivityModelDrummondParams params) -> Ac
         ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
         {
             // The aqueous mixture and its state exported by a base aqueous activity model.
-            const auto& mixture = std::any_cast<AqueousMixture>(props.extra.at(0));
-            const auto& state = std::any_cast<AqueousMixtureState>(props.extra.at(1));
+            const auto& state = std::any_cast<AqueousMixtureState>(props.extra["AqueousMixtureState"]);
 
             const auto& [a1, a2, a3, a4, a5] = params;
             const auto& T = state.T;

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDuanSun.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDuanSun.cpp
@@ -91,8 +91,8 @@ auto ActivityModelDuanSun(String gas) -> ActivityModelGenerator
         ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
         {
             // The aqueous mixture and its state exported by a base aqueous activity model.
-            const auto& mixture = std::any_cast<AqueousMixture>(props.extra.at(0));
-            const auto& state = std::any_cast<AqueousMixtureState>(props.extra.at(1));
+            const auto& mixture = std::any_cast<AqueousMixture>(props.extra["AqueousMixture"]);
+            const auto& state = std::any_cast<AqueousMixtureState>(props.extra["AqueousMixtureState"]);
 
             // The local indices of some charged species among all charged species
             static const auto iNa  = mixture.charged().findWithFormula("Na+");

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelHKF.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelHKF.cpp
@@ -346,7 +346,8 @@ auto activityModelHKF(const SpeciesList& species) -> ActivityModel
         state = mixture.state(T, P, x);
 
         // Export the aqueous mixture and its state via the `extra` data member
-        props.extra = { mixture, state };
+        props.extra["AqueousMixtureState"] = state;
+        props.extra["AqueousMixture"] = mixture;
 
         // Auxiliary references to state variables
         const auto& I = state.Is;  // the stoichiometric ionic strength

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelHKF.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelHKF.cpp
@@ -19,7 +19,6 @@
 
 // C++ includes
 #include <map>
-#include <string>
 #include <vector>
 
 // Reaktoro includes

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelPitzerHMW.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelPitzerHMW.cpp
@@ -1398,7 +1398,8 @@ auto activityModelPitzerHMW(const SpeciesList& species) -> ActivityModel
         state = mixture.state(T, P, x);
 
         // Export the aqueous mixture and its state via the `extra` data member
-        props.extra = { mixture, state };
+        props.extra["AqueousMixtureState"] = state;
+        props.extra["AqueousMixture"] = mixture;
 
         // Calculate the activity coefficients of the cations
         for(auto M = 0; M < pitzer.idx_cations.size(); ++M)

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelRumpf.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelRumpf.cpp
@@ -34,8 +34,8 @@ auto ActivityModelRumpf(String gas) -> ActivityModelGenerator
         ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
         {
             // The aqueous mixture and its state exported by a base aqueous activity model.
-            const auto& mixture = std::any_cast<AqueousMixture>(props.extra.at(0));
-            const auto& state = std::any_cast<AqueousMixtureState>(props.extra.at(1));
+            const auto& mixture = std::any_cast<AqueousMixture>(props.extra["AqueousMixture"]);
+            const auto& state = std::any_cast<AqueousMixtureState>(props.extra["AqueousMixtureState"]);
 
             // The local indices of some charged species among all charged species
             static const auto iNa  = mixture.charged().findWithFormula("Na+");

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelSetschenow.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelSetschenow.cpp
@@ -35,8 +35,7 @@ auto ActivityModelSetschenow(String neutral, real b) -> ActivityModelGenerator
         ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
         {
             // The aqueous mixture and its state exported by a base aqueous activity model.
-            const auto& mixture = std::any_cast<AqueousMixture>(props.extra.at(0));
-            const auto& state = std::any_cast<AqueousMixtureState>(props.extra.at(1));
+            const auto& state = std::any_cast<AqueousMixtureState>(props.extra["AqueousMixtureState"]);
 
             const auto& I = state.Is;
             props.ln_g[ineutral] = ln10 * b * I;

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -36,7 +36,6 @@ using namespace tabulate;
 #include <Reaktoro/Core/ChemicalSystem.hpp>
 #include <Reaktoro/Core/Phase.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
-#include <Reaktoro/Thermodynamics/Water/WaterConstants.hpp>
 
 namespace Reaktoro {
 namespace  {

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -92,6 +92,9 @@ struct AqueousProps::Impl
     /// The echelon form of the formula matrix of the aqueous species.
     Optima::Echelonizer echelonizer;
 
+    /// The extra data mapped to activity model of particular phase that may be reused by subsequent phases.
+    Map<String, Any> m_extra;
+
     Impl(const ChemicalSystem& system)
     : system(system),
       iphase(indexAqueousPhase(system)),
@@ -149,7 +152,7 @@ struct AqueousProps::Impl
         const auto n = state.speciesAmounts();
         const auto ifirst = system.phases().numSpeciesUntilPhase(iphase);
         const auto size = phase.species().size();
-        props.update(T, P, n.segment(ifirst, size));
+        props.update(T, P, n.segment(ifirst, size), m_extra);
         update(props);
     }
 

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -92,7 +92,7 @@ struct AqueousProps::Impl
     /// The echelon form of the formula matrix of the aqueous species.
     Optima::Echelonizer echelonizer;
 
-    /// The extra data mapped to activity model of particular phase that may be reused by subsequent phases.
+    /// The extra properties and data produced during the evaluation of the aqueous phase activity model.
     Map<String, Any> m_extra;
 
     Impl(const ChemicalSystem& system)

--- a/Reaktoro/Thermodynamics/Fluids/ActivityModelCubicEOS.cpp
+++ b/Reaktoro/Thermodynamics/Fluids/ActivityModelCubicEOS.cpp
@@ -20,7 +20,6 @@
 // Reaktoro includes
 #include <Reaktoro/Common/Exception.hpp>
 #include <Reaktoro/Core/Phase.hpp>
-#include <Reaktoro/Core/StateOfMatter.hpp>
 #include <Reaktoro/Singletons/CriticalProps.hpp>
 #include <Reaktoro/Thermodynamics/Fluids/CubicEOS.hpp>
 
@@ -33,7 +32,7 @@ auto activityModelCubicEOS(const SpeciesList& species, ActivityModelCubicEOSPara
     // The number of gases
     const auto nspecies = species.size();
 
-    // Get the the critical temperatures, pressures and acentric factors of the gases
+    // Get the critical temperatures, pressures and acentric factors of the gases
     ArrayXr Tcr(nspecies), Pcr(nspecies), omega(nspecies);
     for(auto i = 0; i < nspecies; ++i)
     {

--- a/Reaktoro/Thermodynamics/Fluids/ActivityModelSpycherReed.cpp
+++ b/Reaktoro/Thermodynamics/Fluids/ActivityModelSpycherReed.cpp
@@ -17,10 +17,6 @@
 
 #include "ActivityModelSpycherReed.hpp"
 
-// C++ includes
-#include <string>
-#include <vector>
-
 // Reaktoro includes
 #include <Reaktoro/Common/Algorithms.hpp>
 #include <Reaktoro/Common/Constants.hpp>

--- a/Reaktoro/Thermodynamics/Fluids/CubicEOS.cpp
+++ b/Reaktoro/Thermodynamics/Fluids/CubicEOS.cpp
@@ -181,7 +181,7 @@ struct CubicEOS::Impl
     /// The number of species in the phase.
     unsigned nspecies;
 
-    /// The fluid type for which the equation of state should be confifured.
+    /// The fluid type for which the equation of state should be configured.
     CubicEOSFluidType fluidtype = CubicEOSFluidType::Vapor;
 
     /// The type of the cubic equation of state.
@@ -261,7 +261,7 @@ struct CubicEOS::Impl
             aT[k]  = factor*alphaT;
             aTT[k] = factor*alphaTT;
             b[k]   = Omega*R*Tcr[k]/Pcr[k]; // Eq. (3.44)
-        };
+        }
 
         // Calculate the binary interaction parameters and its temperature derivatives
         CubicEOSInteractionParams ip;
@@ -361,7 +361,7 @@ struct CubicEOS::Impl
                 Exception exception;
                 exception.error << "Could not calculate the cubic equation of state.";
                 exception.reason << "Logic error: it was expected Z roots of size 3, but got: " << Zs.size();
-                RaiseError(exception);
+                RaiseError(exception)
             }
             Zs.push_back(cubicEOS_roots[0]);  // Z_max
             Zs.push_back(cubicEOS_roots[2]);  // Z_min

--- a/Reaktoro/Thermodynamics/Fluids/PhaseIdentification.cpp
+++ b/Reaktoro/Thermodynamics/Fluids/PhaseIdentification.cpp
@@ -105,7 +105,7 @@ auto pressureComparison(
     });
     real_roots.resize(new_end - real_roots.begin());
 
-    if (real_roots.size() == 0)
+    if (real_roots.empty())
     {
         return CubicEOSFluidType::Vapor;
     }
@@ -125,7 +125,7 @@ auto pressureComparison(
     Exception exception;
     exception.error << "Could not define phase type.";
     exception.reason << "gibbsEnergyAndEquationOfStateMethod has received one Z but the pressure is between Pmin and Pmax.";
-    RaiseError(exception);
+    RaiseError(exception)
 }
 
 
@@ -188,7 +188,7 @@ auto identifyPhaseUsingGibbsEnergyAndEos(
         exception.error << "identifyPhaseUsingGibbsEnergyAndEos received invalid input";
         exception.reason << "Zs should have size 1 or 2 in identifyPhaseUsingGibbsEnergyAndEos, "
             << "but has a size of " << Zs.size();
-        RaiseError(exception);
+        RaiseError(exception)
     }
 
     const real& Z_min = Zs[0] < Zs[1] ? Zs[0] : Zs[1];

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
@@ -1,0 +1,56 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#include "ActivityModelIdealIonExchange.hpp"
+
+// Reaktoro includes
+#include <Reaktoro/Singletons/Elements.hpp>
+
+namespace Reaktoro {
+
+auto ActivityModelIdealIonExchange() -> ActivityModelGenerator
+{
+    ActivityModelGenerator model = [](const SpeciesList& species)
+    {
+        // Initialize exchanger's equivalents by parsing the elements of the ion exchange species
+        const auto num_species = species.size();
+        ArrayXd ze = ArrayXr::Zero(num_species);
+        // TODO: replace it with the unified function similar to `detail::exchangerEquivalentsNumber` in `ActivityModelIonExchange.cpp` file
+        for(auto i = 0; i < num_species; ++i)
+            for(auto [element, coeff] : species[i].elements())
+                if(!Elements::withSymbol(element.symbol()))
+                    ze[i] = coeff;
+
+        ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
+        {
+            // Fetch species fractions for the activity model evaluation
+            const auto x = args.x;
+
+            // Export the exchanger equivalents of ion exchange composition via `extra` data member
+            props.extra["ExchangerEquivalents"] = ze;
+
+            // Calculate the ln of activities as lon of equivalence fractions
+            props.ln_a = (x*ze/(x*ze).sum()).log();
+        };
+
+        return fn;
+    };
+
+    return model;
+}
+
+} // namespace Reaktoro

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
@@ -35,17 +35,12 @@ auto ActivityModelIdealIonExchange() -> ActivityModelGenerator
         const auto num_species = species.size();
         ArrayXd ze = ArrayXr::Zero(num_species);
         for(auto i = 0; i < num_species; ++i)
-            for(auto [element, coeff] : species[i].elements())
-                if(!Elements::withSymbol(element.symbol()))
-                    ze[i] = coeff;
+            ze[i] = detail::exchangerEquivalentsNumber(species[i]);
 
         ActivityModel fn = [=](ActivityPropsRef props, ActivityArgs args)
         {
             // Fetch species fractions for the activity model evaluation
             const auto x = args.x;
-
-            // Export the exchanger equivalents of ion exchange composition via `extra` data member
-            props.extra["ExchangerEquivalents"] = ze;
 
             // Calculate the ln of activities as lon of equivalence fractions
             props.ln_a = (x*ze/(x*ze).sum()).log();

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.cpp
@@ -22,6 +22,11 @@
 
 namespace Reaktoro {
 
+namespace detail
+{
+extern auto exchangerEquivalentsNumber(const Species& species) -> real;
+}
+
 auto ActivityModelIdealIonExchange() -> ActivityModelGenerator
 {
     ActivityModelGenerator model = [](const SpeciesList& species)
@@ -29,7 +34,6 @@ auto ActivityModelIdealIonExchange() -> ActivityModelGenerator
         // Initialize exchanger's equivalents by parsing the elements of the ion exchange species
         const auto num_species = species.size();
         ArrayXd ze = ArrayXr::Zero(num_species);
-        // TODO: replace it with the unified function similar to `detail::exchangerEquivalentsNumber` in `ActivityModelIonExchange.cpp` file
         for(auto i = 0; i < num_species; ++i)
             for(auto [element, coeff] : species[i].elements())
                 if(!Elements::withSymbol(element.symbol()))

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.hpp
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.hpp
@@ -1,0 +1,28 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// Reaktoro includes
+#include <Reaktoro/Core/ActivityModel.hpp>
+
+namespace Reaktoro {
+
+/// Return the activity model for the ideal ion exchange.
+auto ActivityModelIdealIonExchange() -> ActivityModelGenerator;
+
+} // namespace Reaktoro

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.py
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.py
@@ -1,0 +1,25 @@
+# Reaktoro is a unified framework for modeling chemically reactive systems.
+#
+# Copyright © 2014-2021 Allan Leal
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+
+from reaktoro import *
+import pytest
+
+
+# TODO Implement tests for the python bindings of component ActivityModelIdealIonExchange in ActivityModelIdealIonExchange.py
+def testActivityModelIdealIonExchange():
+    pass

--- a/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.py.cxx
+++ b/Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.py.cxx
@@ -1,0 +1,29 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// pybind11 includes
+#include <Reaktoro/pybind11.hxx>
+
+// Reaktoro includes
+#include <Reaktoro/Thermodynamics/Ideal/ActivityModelIdealIonExchange.hpp>
+
+using namespace Reaktoro;
+
+void exportActivityModelIdealIonExchange(py::module& m)
+{
+    m.def("ActivityModelIdealIonExchange", ActivityModelIdealIonExchange);
+}

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -123,7 +123,6 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
                 //            std::cout << phreeqc_species->dha << std::endl;
                 //            std::cout << phreeqc_species->dhb << std::endl;
                 //            std::cout << phreeqc_species->a_f << std::endl;
-                //            getchar();
                 // Calculate activity coefficients according to the Debye--Huckel model
                 // TODO: obtained from each species if it have parameter -gamma provided
                 //            const auto a = phreeqc_species->dha;
@@ -143,9 +142,6 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
 //                ln_g[i] = ln10*(-Agamma*ze[i]*ze[i]*sqrtI/(1 + sqrtI) - 0.3 * I);
             }
         }
-
-        std::cout << "ln_g = " << ln_g << std::endl;
-        getchar();
         // Calculate the ln of activities
         ln_a = ln_g + ln_beta;
     };

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -97,7 +97,7 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
                 const auto a = phreeqc_species->dha;
                 const auto b = phreeqc_species->dhb;
 
-                if(b == 99.9) // the Phreeqc huck used while reading the dat-file, which indicate to use Davies activity model
+                if(b == 99.9) // the Phreeqc hack used while reading the dat-file, which indicate to use Davies activity model
                 {
                     // Calculate the ln activity coefficient of the exchange species using the Davies activity model
                     ln_g[i] = ln10*(-Agamma*ze[i]*ze[i]*sqrtI/(1 + sqrtI) - 0.3*I);

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -86,9 +86,6 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
         auto& ln_g = props.ln_g;
         auto& ln_a = props.ln_a;
 
-        // Export the exchanger equivalents of ion exchange composition via `extra` data member
-        props.extra["ExchangerEquivalents"] = ze;
-
         // Calculate the ln of equivalence fractions
         const auto ln_beta = (x*ze/(x*ze).sum()).log();
 

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -30,6 +30,26 @@ using std::log;
 
 namespace detail {
 
+Map<String, std::vector<real>> gammas_phreeqc =
+{
+    { "NaX"   , {4.08, 0.082}  },
+    { "KX"    , {3.50, 0.015}  },
+    { "LiX"   , {6.00, 0.000}  },
+    { "NH4X"  , {2.50, 0.000}  },
+    { "CaX2"  , {5.00, 0.165}  },
+    { "MgX2"  , {5.50, 0.200}  },
+    { "SrX2"  , {5.26, 0.121}  },
+    { "BaX2"  , {4.00, 0.153}  },
+    { "MnX2"  , {6.00, 0.000}  },
+    { "FeX2"  , {6.00, 0.000}  },
+    { "CuX2"  , {6.00, 0.000}  },
+    { "ZnX2"  , {5.00, 0.000}  },
+    { "CdX2"  , {0.00, 0.000}  },
+    { "PbX2"  , {0.00, 0.165}  },
+    { "AlX3"  , {9.00, 0.200}  },
+    { "AlOHX2", {0.00, 0.000}  },
+};
+
 // Return the number of exchanger's equivalents (the charge of cations) in the ion exchange species.
 auto exchangerEquivalentsNumber(const Species& species) -> real
 {
@@ -108,22 +128,24 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
                 // TODO: obtained from each species if it have parameter -gamma provided
                 //            const auto a = phreeqc_species->dha;
                 //            const auto b = phreeqc_species->dhb;
-                const auto a = 1.0;
-                const auto b = 1.0;
+                const auto a = gammas_phreeqc[species[i].name()].at(0);
+                const auto b = gammas_phreeqc[species[i].name()].at(1);
 
                 // Calculate the ln activity coefficient of the exchange species
                 ln_g[i] = ln10*(-A*ze[i]*ze[i]*sqrtI/(1.0 + a*B*sqrtI) + b*I);
 
-                // ---------------------------------------------------------------------------//
-                // Calculate activity coefficients according top the Davies model
-
-                // Calculate the ln activity coefficient of the echange species
-                // Debye-Huckel parameter
-                const auto Agamma = 0.5095;
-                ln_g[i] = ln10*(-Agamma*ze[i]*ze[i]*sqrtI/(1 + sqrtI) - 0.3 * I);
+//                // ---------------------------------------------------------------------------//
+//                // Calculate activity coefficients according top the Davies model
+//
+//                // Calculate the ln activity coefficient of the echange species
+//                // Debye-Huckel parameter
+//                const auto Agamma = 0.5095;
+//                ln_g[i] = ln10*(-Agamma*ze[i]*ze[i]*sqrtI/(1 + sqrtI) - 0.3 * I);
             }
         }
 
+        std::cout << "ln_g = " << ln_g << std::endl;
+        getchar();
         // Calculate the ln of activities
         ln_a = ln_g + ln_beta;
     };

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -30,7 +30,7 @@ using std::log;
 
 namespace detail {
 
-Map<String, std::vector<real>> gammas_phreeqc =
+Map<String, Vec<real>> gammas_phreeqc =
 {
     { "NaX"   , {4.08, 0.082}  },
     { "KX"    , {3.50, 0.015}  },

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -63,8 +63,8 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
         auto& ln_g = props.ln_g;
         auto& ln_a = props.ln_a;
 
-        // Export the aqueous mixture and its state via the `extra` data member
-        props.extra = { ze };
+        // Export the exchanger equivalents of ion exchange composition via `extra` data member
+        props.extra["ExchangerEquivalents"] = ze;
 
         // Calculate the ln of equivalence fractions
         const auto ln_beta = (x*ze/(x*ze).sum()).log();

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.cpp
@@ -20,10 +20,13 @@
 // Reaktoro includes
 #include <Reaktoro/Singletons/Elements.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
+#include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
+#include <Reaktoro/Extensions/Phreeqc/PhreeqcLegacy.hpp>
 
 namespace Reaktoro {
 
 using std::sqrt;
+using std::log;
 
 namespace detail {
 
@@ -66,11 +69,57 @@ auto activityModelIonExchangeGainesThomas(const SpeciesList& species) -> Activit
         // Export the exchanger equivalents of ion exchange composition via `extra` data member
         props.extra["ExchangerEquivalents"] = ze;
 
+        // Export aqueous mixture state via `extra` data member
+        const auto& state = std::any_cast<AqueousMixtureState>(props.extra["AqueousMixtureState"]);
+
+        // Auxiliary constant references properties
+        const auto& I = state.Is;            // the stoichiometric ionic strength
+        const auto& rho = state.rho/1000;    // the density of water (in g/cm3)
+        const auto& epsilon = state.epsilon; // the dielectric constant of water
+
+        // Auxiliary variables
+        const auto sqrtI = sqrt(I);
+        const auto sqrt_rho = sqrt(rho);
+        const auto T_epsilon = T * epsilon;
+        const auto sqrt_T_epsilon = sqrt(T_epsilon);
+        const auto A = 1.824829238e+6 * sqrt_rho/(T_epsilon*sqrt_T_epsilon);
+        const auto B = 50.29158649 * sqrt_rho/sqrt_T_epsilon;
+        const auto ln10 = log(10);
+
         // Calculate the ln of equivalence fractions
         const auto ln_beta = (x*ze/(x*ze).sum()).log();
 
         // Calculate the ln of activity coefficients
         ln_g = ArrayXr::Zero(num_species);
+
+        // Loop over all species in the composition
+        for(Index i = 0; i < num_species; ++i)
+        {
+//            const auto phreeqc_species = std::any_cast<PhreeqcSpecies*>(species[i].attachedData());
+//            std::cout << phreeqc_species->name << "" << phreeqc_species->dw << std::endl;
+//            std::cout << phreeqc_species->dha << std::endl;
+//            std::cout << phreeqc_species->dhb << std::endl;
+//            std::cout << phreeqc_species->a_f << std::endl;
+//            getchar();
+            // Calculate activity coefficients according to the Debye--Huckel model
+            // TODO: obtained from each species if it have parameter -gamma provided
+//            const auto a = phreeqc_species->dha;
+//            const auto b = phreeqc_species->dhb;
+            const auto a = 1.0;
+            const auto b = 1.0;
+
+            // Calculate the ln activity coefficient of the exchange species
+            ln_g[i] = ln10*(-A*ze[i]*ze[i]*sqrtI/(1.0 + a*B*sqrtI) + b*I);
+
+            // ---------------------------------------------------------------------------//
+            // Calculate activity coefficients according top the Davies model
+
+            // Calculate the ln activity coefficient of the echange species
+            // Debye-Huckel parameter
+            const auto Agamma = 0.5095;
+            ln_g[i] = ln10*(-Agamma*ze[i]*ze[i]*sqrtI/(1 + sqrtI) - 0.3 * I);
+        }
+
 
         // Calculate the ln of activities
         ln_a = ln_g + ln_beta;

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.py
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.py
@@ -27,6 +27,7 @@ def initializeMoleFractions(species):
 
     n = 1e-6 * np.ones(species.size())
 
+    n[idx("X-")]   = 0.1
     n[idx("MgX2")] = 0.1
     n[idx("CaX2")] = 0.2
     n[idx("NaX")]  = 0.3
@@ -39,26 +40,26 @@ def testActivityModelIonExchage():
     db = PhreeqcDatabase("phreeqc.dat")
 
     # Expected species: AlOHX2 AlX3 BaX2 CaX2 CdX2 CuX2 FeX2 KX LiX MgX2 MnX2 NH4X NaX PbX2 SrX2 ZnX2
-    exchange_species = db.species().withAggregateState(AggregateState.IonExchange)
-    species = SpeciesList([s for s in exchange_species if not(s.charge())])
+    species = db.species().withAggregateState(AggregateState.IonExchange)
 
     # Check the names of the species
-    assert species[0].name() == "AlOHX2"
-    assert species[1].name()  == "AlX3"
-    assert species[2].name()  == "BaX2"
-    assert species[3].name()  == "CaX2"
-    assert species[4].name()  == "CdX2"
-    assert species[5].name()  == "CuX2"
-    assert species[6].name()  == "FeX2"
-    assert species[7].name()  == "KX"
-    assert species[8].name()  == "LiX"
-    assert species[9].name()  == "MgX2"
-    assert species[10].name() == "MnX2"
-    assert species[11].name() == "NH4X"
-    assert species[12].name() == "NaX"
-    assert species[13].name() == "PbX2"
-    assert species[14].name() == "SrX2"
-    assert species[15].name() == "ZnX2"
+    assert species[0].name()  == "X-"
+    assert species[1].name()  == "AlOHX2"
+    assert species[2].name()  == "AlX3"
+    assert species[3].name()  == "BaX2"
+    assert species[4].name()  == "CaX2"
+    assert species[5].name()  == "CdX2"
+    assert species[6].name()  == "CuX2"
+    assert species[7].name()  == "FeX2"
+    assert species[8].name()  == "KX"
+    assert species[9].name()  == "LiX"
+    assert species[10].name() == "MgX2"
+    assert species[11].name() == "MnX2"
+    assert species[12].name() == "NH4X"
+    assert species[13].name() == "NaX"
+    assert species[14].name() == "PbX2"
+    assert species[15].name() == "SrX2"
+    assert species[16].name() == "ZnX2"
 
     # Initialize input data for the ActivityProps
     T = autodiff.real(300.0)

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
@@ -83,7 +83,7 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         fn(props, {T, P, x});
 
         // Fetch exchanger equivalents in the ion exchange species
-        const auto& ze = std::any_cast<ArrayXd>(props.extra.at(0));
+        const auto& ze = std::any_cast<ArrayXd>(props.extra["ExchangerEquivalents"]);
 
         CHECK( ze[0]  == 2 ); // AlOHX2
         CHECK( ze[1]  == 3 ); // AlX3

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
@@ -81,7 +81,7 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         CHECK(species[7].name()  == "FeX2"   ); // FeX2
         CHECK(species[8].name()  == "KX"     ); // KX
         CHECK(species[9].name()  == "LiX"    ); // LiX
-        CHECK(species[10].name()  == "MgX2"   ); // MgX2
+        CHECK(species[10].name() == "MgX2"   ); // MgX2
         CHECK(species[11].name() == "MnX2"   ); // MnX2
         CHECK(species[12].name() == "NH4X"   ); // NH4X
         CHECK(species[13].name() == "NaX"    ); // NaX
@@ -142,7 +142,7 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         CHECK( props.ln_a[7]  == Approx(-13.017)   ); // FeX2
         CHECK( props.ln_a[8]  == Approx(-13.7102)  ); // KX
         CHECK( props.ln_a[9]  == Approx(-13.7102)  ); // LiX
-        CHECK( props.ln_a[10]  == Approx(-1.5041)   ); // MgX2
+        CHECK( props.ln_a[10] == Approx(-1.5041)   ); // MgX2
         CHECK( props.ln_a[11] == Approx(-13.017)   ); // MnX2
         CHECK( props.ln_a[12] == Approx(-13.7102)  ); // NH4X
         CHECK( props.ln_a[13] == Approx(-1.09864)  ); // NaX
@@ -184,7 +184,7 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         CHECK( props.ln_g[7]  == Approx(-1.31534)  ); // FeX2
         CHECK( props.ln_g[8]  == Approx(-0.41378)  ); // KX
         CHECK( props.ln_g[9]  == Approx(-0.328835) ); // LiX
-        CHECK( props.ln_g[10]  == Approx(-1.19483)  ); // MgX2
+        CHECK( props.ln_g[10] == Approx(-1.19483)  ); // MgX2
         CHECK( props.ln_g[11] == Approx(-1.31534)  ); // MnX2
         CHECK( props.ln_g[12] == Approx(-0.485979) ); // NH4X
         CHECK( props.ln_g[13] == Approx(-0.324217) ); // NaX
@@ -202,7 +202,7 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         CHECK( props.ln_a[7]  == Approx(-14.3324)  ); // FeX2
         CHECK( props.ln_a[8]  == Approx(-14.1240)  ); // KX
         CHECK( props.ln_a[9]  == Approx(-14.039)   ); // LiX
-        CHECK( props.ln_a[10]  == Approx( -2.69894) ); // MgX2
+        CHECK( props.ln_a[10] == Approx( -2.69894) ); // MgX2
         CHECK( props.ln_a[11] == Approx(-14.3324)  ); // MnX2
         CHECK( props.ln_a[12] == Approx(-14.1962)  ); // NH4X
         CHECK( props.ln_a[13] == Approx(-1.42286)  ); // NaX

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
@@ -21,6 +21,7 @@
 // Reaktoro includes
 #include <Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.hpp>
 #include <Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.hpp>
+#include <Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousMixture.hpp>
 
@@ -32,6 +33,7 @@ inline auto initializeMoleFractions(const SpeciesList& species) -> ArrayXr
     auto idx = [&](auto formula) { return species.indexWithFormula(formula); };
 
     ArrayXr n = 1e-6 * ArrayXr::Ones(species.size());
+    n[idx("X-")] = 0.1;
     n[idx("MgX2")] = 0.1;
     n[idx("CaX2" )] = 0.2;
     n[idx("NaX")] = 0.3;
@@ -60,30 +62,59 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
     // Load phreeqc database
     PhreeqcDatabase db("phreeqc.dat");
 
-    // Define ion exchange species list and corresponding fractions
-    // Expected species: AlOHX2 AlX3 BaX2 CaX2 CdX2 CuX2 FeX2 KX LiX MgX2 MnX2 NH4X NaX PbX2 SrX2 ZnX2
-    SpeciesList species = filter(db.species().withAggregateState(AggregateState::IonExchange),
-                                 [](const Species& s){ return !s.charge();});
+    // Define ion exchange species list
+    // Expected species: X- AlOHX2 AlX3 BaX2 CaX2 CdX2 CuX2 FeX2 KX LiX MgX2 MnX2 NH4X NaX PbX2 SrX2 ZnX2
+    SpeciesList species = db.species().withAggregateState(AggregateState::IonExchange);
+
+    // Initialize corresponding species fractions
     const auto x = initializeMoleFractions(species);
 
     SECTION("Checking the species")
     {
-        CHECK(species[0].name()  == "AlOHX2" ); // AlOHX2
-        CHECK(species[1].name()  == "AlX3"   ); // AlX3
-        CHECK(species[2].name()  == "BaX2"   ); // BaX2
-        CHECK(species[3].name()  == "CaX2"   ); // CaX2
-        CHECK(species[4].name()  == "CdX2"   ); // CdX2
-        CHECK(species[5].name()  == "CuX2"   ); // CuX2
-        CHECK(species[6].name()  == "FeX2"   ); // FeX2
-        CHECK(species[7].name()  == "KX"     ); // KX
-        CHECK(species[8].name()  == "LiX"    ); // LiX
-        CHECK(species[9].name()  == "MgX2"   ); // MgX2
-        CHECK(species[10].name() == "MnX2"   ); // MnX2
-        CHECK(species[11].name() == "NH4X"   ); // NH4X
-        CHECK(species[12].name() == "NaX"    ); // NaX
-        CHECK(species[13].name() == "PbX2"   ); // PbX2
-        CHECK(species[14].name() == "SrX2"   ); // SrX2
-        CHECK(species[15].name() == "ZnX2"   ); // ZnX2
+        CHECK(species[0].name()  == "X-"     ); // X-
+        CHECK(species[1].name()  == "AlOHX2" ); // AlOHX2
+        CHECK(species[2].name()  == "AlX3"   ); // AlX3
+        CHECK(species[3].name()  == "BaX2"   ); // BaX2
+        CHECK(species[4].name()  == "CaX2"   ); // CaX2
+        CHECK(species[5].name()  == "CdX2"   ); // CdX2
+        CHECK(species[6].name()  == "CuX2"   ); // CuX2
+        CHECK(species[7].name()  == "FeX2"   ); // FeX2
+        CHECK(species[8].name()  == "KX"     ); // KX
+        CHECK(species[9].name()  == "LiX"    ); // LiX
+        CHECK(species[10].name()  == "MgX2"   ); // MgX2
+        CHECK(species[11].name() == "MnX2"   ); // MnX2
+        CHECK(species[12].name() == "NH4X"   ); // NH4X
+        CHECK(species[13].name() == "NaX"    ); // NaX
+        CHECK(species[14].name() == "PbX2"   ); // PbX2
+        CHECK(species[15].name() == "SrX2"   ); // SrX2
+        CHECK(species[16].name() == "ZnX2"   ); // ZnX2
+    }
+
+    SECTION("Checking the charges")
+    {
+        // Create the aqueous mixture
+        IonExchangeSurface surface(species);
+
+        // The numbers of exchanger's equivalents for exchange species
+        ArrayXd ze = surface.ze();
+
+        CHECK( ze[0]  == 0 ); // X-
+        CHECK( ze[1]  == 2 ); // AlOHX2
+        CHECK( ze[2]  == 3 ); // AlX3
+        CHECK( ze[3]  == 2 ); // BaX2
+        CHECK( ze[4]  == 2 ); // CaX2
+        CHECK( ze[5]  == 2 ); // CdX2
+        CHECK( ze[6]  == 2 ); // CuX2
+        CHECK( ze[7]  == 2 ); // FeX2
+        CHECK( ze[8]  == 1 ); // KX
+        CHECK( ze[9]  == 1 ); // LiX
+        CHECK( ze[10] == 2 ); // MgX2
+        CHECK( ze[11] == 2 ); // MnX2
+        CHECK( ze[12] == 1 ); // NH4X
+        CHECK( ze[13] == 1 ); // NaX
+        CHECK( ze[14] == 2 ); // PbX2
+        CHECK( ze[15] == 2 ); // SrX2
+        CHECK( ze[16] == 2 ); // ZnX2
     }
 
     // Initialize input data for the ActivityProps
@@ -101,29 +132,30 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( props.ln_a[0]  == Approx(-13.017)   ); // AlOHX2
-        CHECK( props.ln_a[1]  == Approx(-12.6116)  ); // AlX3
-        CHECK( props.ln_a[2]  == Approx(-13.017)   ); // BaX2
-        CHECK( props.ln_a[3]  == Approx(-0.810957) ); // CaX2
-        CHECK( props.ln_a[4]  == Approx(-13.017)   ); // CdX2
-        CHECK( props.ln_a[5]  == Approx(-13.017)   ); // CuX2
-        CHECK( props.ln_a[6]  == Approx(-13.017)   ); // FeX2
-        CHECK( props.ln_a[7]  == Approx(-13.7102)  ); // KX
-        CHECK( props.ln_a[8]  == Approx(-13.7102)  ); // LiX
-        CHECK( props.ln_a[9]  == Approx(-1.5041)   ); // MgX2
-        CHECK( props.ln_a[10] == Approx(-13.017)   ); // MnX2
-        CHECK( props.ln_a[11] == Approx(-13.7102)  ); // NH4X
-        CHECK( props.ln_a[12] == Approx(-1.09864)  ); // NaX
-        CHECK( props.ln_a[13] == Approx(-13.017)   ); // PbX2
-        CHECK( props.ln_a[14] == Approx(-13.017)   ); // SrX2
-        CHECK( props.ln_a[15] == Approx(-13.017)   ); // ZnX2
+        CHECK( props.ln_a[0]  == Approx(  0.0)     ); // X-
+        CHECK( props.ln_a[1]  == Approx(-13.017)   ); // AlOHX2
+        CHECK( props.ln_a[2]  == Approx(-12.6116)  ); // AlX3
+        CHECK( props.ln_a[3]  == Approx(-13.017)   ); // BaX2
+        CHECK( props.ln_a[4]  == Approx(-0.810957) ); // CaX2
+        CHECK( props.ln_a[5]  == Approx(-13.017)   ); // CdX2
+        CHECK( props.ln_a[6]  == Approx(-13.017)   ); // CuX2
+        CHECK( props.ln_a[7]  == Approx(-13.017)   ); // FeX2
+        CHECK( props.ln_a[8]  == Approx(-13.7102)  ); // KX
+        CHECK( props.ln_a[9]  == Approx(-13.7102)  ); // LiX
+        CHECK( props.ln_a[10]  == Approx(-1.5041)   ); // MgX2
+        CHECK( props.ln_a[11] == Approx(-13.017)   ); // MnX2
+        CHECK( props.ln_a[12] == Approx(-13.7102)  ); // NH4X
+        CHECK( props.ln_a[13] == Approx(-1.09864)  ); // NaX
+        CHECK( props.ln_a[14] == Approx(-13.017)   ); // PbX2
+        CHECK( props.ln_a[15] == Approx(-13.017)   ); // SrX2
+        CHECK( props.ln_a[16] == Approx(-13.017)   ); // ZnX2
     }
 
     // Define aqueous species list and corresponding fractions
     const auto species_aq = SpeciesList("H2O H+ OH- Na+ Cl- NaCl");
     const auto x_aq = initializeAqueousMoleFractions(species_aq);
 
-    SECTION("Checking the activities coefficients (calculated based on the parameters fetched from phreeqc.dat)")
+    SECTION("Checking the activities coefficients and activities (calculated based on the parameters fetched from phreeqc.dat)")
     {
         // Create the aqueous mixture
         AqueousMixture mixture(species_aq);
@@ -142,21 +174,40 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( props.ln_g[0]  == Approx(-2.95134)  ); // AlOHX2
-        CHECK( props.ln_g[1]  == Approx(-2.13305)  ); // AlX3
-        CHECK( props.ln_g[2]  == Approx(-1.47255)  ); // BaX2
-        CHECK( props.ln_g[3]  == Approx(-1.29726)  ); // CaX2
-        CHECK( props.ln_g[4]  == Approx(-2.95134)  ); // CdX2
-        CHECK( props.ln_g[5]  == Approx(-1.31534)  ); // CuX2
-        CHECK( props.ln_g[6]  == Approx(-1.31534)  ); // FeX2
-        CHECK( props.ln_g[7]  == Approx(-0.41378)  ); // KX
-        CHECK( props.ln_g[8]  == Approx(-0.328835) ); // LiX
-        CHECK( props.ln_g[9]  == Approx(-1.19483)  ); // MgX2
-        CHECK( props.ln_g[10] == Approx(-1.31534)  ); // MnX2
-        CHECK( props.ln_g[11] == Approx(-0.485979) ); // NH4X
-        CHECK( props.ln_g[12] == Approx(-0.324217) ); // NaX
-        CHECK( props.ln_g[13] == Approx(-2.79937)  ); // PbX2
-        CHECK( props.ln_g[14] == Approx(-1.30042)  ); // SrX2
-        CHECK( props.ln_g[15] == Approx(-1.44923)  ); // ZnX2
+        CHECK( props.ln_g[0]  == Approx( 0.00000)  ); // X-
+        CHECK( props.ln_g[1]  == Approx(-2.09438)  ); // AlOHX2
+        CHECK( props.ln_g[2]  == Approx(-2.31725)  ); // AlX3
+        CHECK( props.ln_g[3]  == Approx(-1.47255)  ); // BaX2
+        CHECK( props.ln_g[4]  == Approx(-1.29726)  ); // CaX2
+        CHECK( props.ln_g[5]  == Approx(-2.09438)  ); // CdX2
+        CHECK( props.ln_g[6]  == Approx(-1.31534)  ); // CuX2
+        CHECK( props.ln_g[7]  == Approx(-1.31534)  ); // FeX2
+        CHECK( props.ln_g[8]  == Approx(-0.41378)  ); // KX
+        CHECK( props.ln_g[9]  == Approx(-0.328835) ); // LiX
+        CHECK( props.ln_g[10]  == Approx(-1.19483)  ); // MgX2
+        CHECK( props.ln_g[11] == Approx(-1.31534)  ); // MnX2
+        CHECK( props.ln_g[12] == Approx(-0.485979) ); // NH4X
+        CHECK( props.ln_g[13] == Approx(-0.324217) ); // NaX
+        CHECK( props.ln_g[14] == Approx(-2.09438)  ); // PbX2
+        CHECK( props.ln_g[15] == Approx(-1.30042)  ); // SrX2
+        CHECK( props.ln_g[16] == Approx(-1.44923)  ); // ZnX2
+
+        CHECK( props.ln_a[0]  == Approx(  0.0000)  ); // X-
+        CHECK( props.ln_a[1]  == Approx(-15.1114)  ); // AlOHX2
+        CHECK( props.ln_a[2]  == Approx(-14.9288)  ); // AlX3
+        CHECK( props.ln_a[3]  == Approx(-14.4896)  ); // BaX2
+        CHECK( props.ln_a[4]  == Approx( -2.10821) ); // CaX2
+        CHECK( props.ln_a[5]  == Approx(-15.1114)  ); // CdX2
+        CHECK( props.ln_a[6]  == Approx(-14.3324)  ); // CuX2
+        CHECK( props.ln_a[7]  == Approx(-14.3324)  ); // FeX2
+        CHECK( props.ln_a[8]  == Approx(-14.1240)  ); // KX
+        CHECK( props.ln_a[9]  == Approx(-14.039)   ); // LiX
+        CHECK( props.ln_a[10]  == Approx( -2.69894) ); // MgX2
+        CHECK( props.ln_a[11] == Approx(-14.3324)  ); // MnX2
+        CHECK( props.ln_a[12] == Approx(-14.1962)  ); // NH4X
+        CHECK( props.ln_a[13] == Approx(-1.42286)  ); // NaX
+        CHECK( props.ln_a[14] == Approx(-15.1114)  ); // PbX2
+        CHECK( props.ln_a[15] == Approx(-14.3174)  ); // SrX2
+        CHECK( props.ln_a[16] == Approx(-14.4663)  ); // ZnX2
     }
 }

--- a/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
+++ b/Reaktoro/Thermodynamics/Surface/ActivityModelIonExchange.test.cxx
@@ -90,38 +90,6 @@ TEST_CASE("Testing ActivityModelIonExchange", "[ActivityModelIonExchange]")
     const auto T = 300.0;
     const auto P = 12.3e5;
 
-    SECTION("Checking the charges")
-    {
-        // Construct the activity model function with the given ion exchange species.
-        ActivityModel fn = ActivityModelIonExchangeGainesThomas()(species);
-
-        // Create the ActivityProps object with the results.
-        ActivityProps props = ActivityProps::create(species.size());
-
-        // Evaluate the activity props function
-        fn(props, {T, P, x});
-
-        // Fetch exchanger equivalents in the ion exchange species
-        const auto& ze = std::any_cast<ArrayXd>(props.extra["ExchangerEquivalents"]);
-
-        CHECK( ze[0]  == 2 ); // AlOHX2
-        CHECK( ze[1]  == 3 ); // AlX3
-        CHECK( ze[2]  == 2 ); // BaX2
-        CHECK( ze[3]  == 2 ); // CaX2
-        CHECK( ze[4]  == 2 ); // CdX2
-        CHECK( ze[5]  == 2 ); // CuX2
-        CHECK( ze[6]  == 2 ); // FeX2
-        CHECK( ze[7]  == 1 ); // KX
-        CHECK( ze[8]  == 1 ); // LiX
-        CHECK( ze[9]  == 2 ); // MgX2
-        CHECK( ze[10] == 2 ); // MnX2
-        CHECK( ze[11] == 1 ); // NH4X
-        CHECK( ze[12] == 1 ); // NaX
-        CHECK( ze[13] == 2 ); // PbX2
-        CHECK( ze[14] == 2 ); // SrX2
-        CHECK( ze[15] == 2 ); // ZnX2
-    }
-
     SECTION("Checking the activities")
     {
         // Construct the activity model function with the given ion exchange species.

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.cpp
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.cpp
@@ -1,0 +1,157 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#include "IonExchangeSurface.hpp"
+
+// Reaktoro includes
+#include <Reaktoro/Common/Algorithms.hpp>
+#include <Reaktoro/Common/Exception.hpp>
+#include <Reaktoro/Singletons/Elements.hpp>
+
+namespace Reaktoro {
+
+struct IonExchangeSurface::Impl
+{
+    /// All species on the ion exchange surface.
+    SpeciesList species;
+
+    /// The ion exchange species on the surface.
+    SpeciesList exchange_species;
+
+    /// The exchanger on the surface.
+    SpeciesList exchanger_species;
+
+    /// The array of exchanger's equivalents numbers for exchange species only (ze.size() = exchange_species.size()).
+    ArrayXd ze;
+
+    /// The index of the exchanger.
+    Index idx_exchanger = 0;
+
+    /// The indices of ion exchange species.
+    Indices idx_exchange_species;
+
+    /// Construct a default IonExchangeSurface::Impl instance.
+    Impl()
+    {}
+
+    /// Construct an IonExchangeSurface::Impl instance with given species.
+    Impl(const SpeciesList& species)
+    : species(species)
+    {
+        /// Initialize the indices related data of the species
+        initializeIndices();
+
+        /// Initialize the array of exchanger's equivalents numbers.
+        initializeExchangerEquivalentsNumbers();
+    }
+
+    // Return the number of exchanger's equivalents (the charge of cations) for the ion exchange species.
+    static auto exchangerEquivalentsNumber(const Species& species) -> real
+    {
+        // Run through the elements of the current species and return the coefficient of the exchanger
+        for(auto [element, coeff] : species.elements())
+            if(!Elements::withSymbol(element.symbol()))
+                return coeff;
+
+            // If all the elements are part of the periodic table then the exchanger is missing
+            errorif(true, "Could not get information about the exchanger equivalents number. "
+                          "Ensure the ion exchange phase contains correct species")
+    }
+
+    /// Initialize the array of exchanger's equivalents numbers (or cation charges) in all species.
+    /// Note: exchanger's equivalents of the exchanger is assumed zero
+    auto initializeExchangerEquivalentsNumbers() -> void
+    {
+        // The number of species in the ion exchange phase only
+        const auto num_species = species.size();
+
+        // The numbers of exchanger's equivalents for exchange species
+        ze = ArrayXr::Zero(num_species);
+
+        // Initialize exchanger's equivalents by parsing the elements of the ion exchange species
+        for(Index i : idx_exchange_species)
+            ze[i] = exchangerEquivalentsNumber(species[i]);
+    }
+
+    /// Initialize the indices related data of the species.
+    auto initializeIndices() -> void
+    {
+        // Initialize the array of indices with charged species
+        Indices idx_charged_species;
+
+        // Initialize the indices of the ion exchange species
+        for(auto i = 0; i < species.size(); ++i)
+            if(species[i].charge() == 0.0)
+                idx_exchange_species.push_back(i);
+            else
+                idx_charged_species.push_back(i);
+
+        // Initialize the index of the exchanger (assuming that it is the only charged species)
+        idx_exchanger = idx_charged_species[0];
+    }
+
+    /// Initialize the lists of species separated into exchanger and exchange species on the surface
+    auto initializeSpecies() -> void
+    {
+        // Separate exchanger (e.g., X-) from exchange species (NaX, KX, NaY, NaY, ect)
+        exchanger_species = filter(species, [](const Species& s){ return s.charge() != 0.0;});
+        exchange_species = filter(species, [](const Species& s){ return s.charge() == 0.0;});
+    }
+
+};
+
+IonExchangeSurface::IonExchangeSurface()
+: pimpl(new Impl())
+{}
+
+IonExchangeSurface::IonExchangeSurface(const SpeciesList& species)
+: pimpl(new Impl(species))
+{}
+
+auto IonExchangeSurface::clone() const -> IonExchangeSurface
+{
+    IonExchangeSurface copy;
+    *copy.pimpl = *pimpl;
+    return copy;
+}
+
+auto IonExchangeSurface::species(Index idx) const -> const Species&
+{
+    return pimpl->species[idx];
+}
+
+auto IonExchangeSurface::species() const -> const SpeciesList&
+{
+    return pimpl->species;
+}
+
+auto IonExchangeSurface::ze() const -> ArrayXdConstRef
+{
+    return pimpl->ze;
+}
+
+auto IonExchangeSurface::indexExchanger() const -> Index
+{
+    return pimpl->idx_exchanger;
+}
+
+auto IonExchangeSurface::indicesExchange() const -> const Indices&
+{
+    return pimpl->idx_exchange_species;
+}
+
+} // namespace Reaktoro

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp
@@ -1,0 +1,67 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// Reaktoro includes
+#include <Reaktoro/Common/Matrix.hpp>
+#include <Reaktoro/Common/Types.hpp>
+#include <Reaktoro/Core/SpeciesList.hpp>
+
+namespace Reaktoro {
+
+/// A type used to describe an ion exchange surface.
+/// The IonExchangeSurface class is defined as a collection of Species objects, representing,
+/// therefore, a composition of ion exchange phase. Its main purpose is to provide the
+/// necessary operations in the calculation of activities of ion exchange species.
+/// It implements methods for the calculation of equivalence fractions of species in ionic
+/// exchange phase. In addition, it provides methods that retrieves information about the
+/// exchanger (e.g., X-) and exchange species (e.g., NaX, CaX2).
+class IonExchangeSurface
+{
+public:
+    /// Construct a default IonExchangeSurface instance.
+    IonExchangeSurface();
+
+    /// Construct an IonExchangeSurface instance with given species.
+    explicit IonExchangeSurface(const SpeciesList& species);
+
+    /// Return a deep copy of this IonExchangeSurface object.
+    auto clone() const -> IonExchangeSurface;
+
+    /// Return the exchange species on the surface with given index.
+    auto species(Index idx) const -> const Species&;
+
+    /// Return the exchange species on the surface.
+    auto species() const -> const SpeciesList&;
+
+    /// Return the indices of the exchanger on the surface.
+    auto indexExchanger() const -> Index;
+
+    /// Return the indices of the exchange species on the surface.
+    auto indicesExchange() const -> const Indices&;
+
+    /// Return the array of exchanger's equivalents numbers (or cation charges) in ion exchange species.
+    auto ze() const -> ArrayXdConstRef;
+
+private:
+    struct Impl;
+
+    SharedPtr<Impl> pimpl;
+};
+
+} // namespace Reaktoro

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py
@@ -50,3 +50,14 @@ def testActivityModelIonExchage():
     assert ze[14] == 2 # PbX2
     assert ze[15] == 2 # SrX2
     assert ze[16] == 2 # ZnX2
+
+    # The numbers of exchanger's equivalents for exchange species
+    idx_exchager = surface.indexExchanger()
+    idx_exchange = surface.indicesExchange()
+
+    expected_exchanger_index = 0 # exchanger is assumed to be on the first place
+    expected_exchange_indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+
+    assert idx_exchager == expected_exchanger_index
+    assert idx_exchange == expected_exchange_indices
+

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py
@@ -1,0 +1,52 @@
+# Reaktoro is a unified framework for modeling chemically reactive systems.
+#
+# Copyright © 2014-2021 Allan Leal
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+
+from reaktoro import *
+import pytest
+
+
+def testActivityModelIonExchage():
+
+    db = PhreeqcDatabase("phreeqc.dat")
+
+    # Expected species: AlOHX2 AlX3 BaX2 CaX2 CdX2 CuX2 FeX2 KX LiX MgX2 MnX2 NH4X NaX PbX2 SrX2 ZnX2
+    species = db.species().withAggregateState(AggregateState.IonExchange)
+
+    # Create the aqueous mixture
+    surface = IonExchangeSurface(species)
+
+    # The numbers of exchanger's equivalents for exchange species
+    ze = surface.ze()
+
+    assert ze[0]  == 0 # X-
+    assert ze[1]  == 2 # AlOHX2
+    assert ze[2]  == 3 # AlX3
+    assert ze[3]  == 2 # BaX2
+    assert ze[4]  == 2 # CaX2
+    assert ze[5]  == 2 # CdX2
+    assert ze[6]  == 2 # CuX2
+    assert ze[7]  == 2 # FeX2
+    assert ze[8]  == 1 # KX
+    assert ze[9]  == 1 # LiX
+    assert ze[10] == 2 # MgX2
+    assert ze[11] == 2 # MnX2
+    assert ze[12] == 1 # NH4X
+    assert ze[13] == 1 # NaX
+    assert ze[14] == 2 # PbX2
+    assert ze[15] == 2 # SrX2
+    assert ze[16] == 2 # ZnX2

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py.cxx
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py.cxx
@@ -1,0 +1,29 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// pybind11 includes
+#include <Reaktoro/pybind11.hxx>
+
+// Reaktoro includes
+#include <Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp>
+
+using namespace Reaktoro;
+
+void exportIonExchangeSurface(py::module& m)
+{
+    m.def("IonExchangeSurface", IonExchangeSurface);
+}

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py.cxx
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.py.cxx
@@ -25,5 +25,13 @@ using namespace Reaktoro;
 
 void exportIonExchangeSurface(py::module& m)
 {
-    m.def("IonExchangeSurface", IonExchangeSurface);
+    py::class_<IonExchangeSurface>(m, "IonExchangeSurface")
+    .def(py::init<const SpeciesList&>())
+    .def("clone", &IonExchangeSurface::clone)
+    .def("species", py::overload_cast<Index>(&IonExchangeSurface::species, py::const_))
+    .def("species", py::overload_cast<>(&IonExchangeSurface::species, py::const_))
+    .def("indicesExchange", &IonExchangeSurface::indicesExchange)
+    .def("indexExchanger", &IonExchangeSurface::indexExchanger)
+    .def("ze", &IonExchangeSurface::ze)
+    ;
 }

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.test.cxx
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeSurface.test.cxx
@@ -1,0 +1,62 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2021 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// Catch includes
+#include <catch2/catch.hpp>
+
+// Reaktoro includes
+#include <Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.hpp>
+#include <Reaktoro/Thermodynamics/Surface/IonExchangeSurface.hpp>
+
+using namespace Reaktoro;
+
+TEST_CASE("Testing IonExchangeSurface", "[IonExchangeSurface]")
+{
+    // Load phreeqc database
+    PhreeqcDatabase db("phreeqc.dat");
+
+    // Define ion exchange species list
+    // Expected species: X- AlOHX2 AlX3 BaX2 CaX2 CdX2 CuX2 FeX2 KX LiX MgX2 MnX2 NH4X NaX PbX2 SrX2 ZnX2
+    SpeciesList species = db.species().withAggregateState(AggregateState::IonExchange);
+
+    SECTION("Checking the charges of the species in IonExchangeSurface")
+    {
+        // Create the aqueous mixture
+        IonExchangeSurface surface(species);
+
+        // The numbers of exchanger's equivalents for exchange species
+        ArrayXd ze = surface.ze();
+
+        CHECK( ze[0]  == 0 ); // X-
+        CHECK( ze[1]  == 2 ); // AlOHX2
+        CHECK( ze[2]  == 3 ); // AlX3
+        CHECK( ze[3]  == 2 ); // BaX2
+        CHECK( ze[4]  == 2 ); // CaX2
+        CHECK( ze[5]  == 2 ); // CdX2
+        CHECK( ze[6]  == 2 ); // CuX2
+        CHECK( ze[7]  == 2 ); // FeX2
+        CHECK( ze[8]  == 1 ); // KX
+        CHECK( ze[9]  == 1 ); // LiX
+        CHECK( ze[10] == 2 ); // MgX2
+        CHECK( ze[11] == 2 ); // MnX2
+        CHECK( ze[12] == 1 ); // NH4X
+        CHECK( ze[13] == 1 ); // NaX
+        CHECK( ze[14] == 2 ); // PbX2
+        CHECK( ze[15] == 2 ); // SrX2
+        CHECK( ze[16] == 2 ); // ZnX2
+    }
+}

--- a/Reaktoro/Thermodynamics/Water/WaterHelmholtzPropsHGK.cpp
+++ b/Reaktoro/Thermodynamics/Water/WaterHelmholtzPropsHGK.cpp
@@ -23,7 +23,6 @@ using std::log;
 using std::pow;
 
 // Reaktoro includes
-#include <Reaktoro/Thermodynamics/Water/WaterConstants.hpp>
 #include <Reaktoro/Thermodynamics/Water/WaterHelmholtzProps.hpp>
 
 namespace Reaktoro {

--- a/Reaktoro/Thermodynamics/Water/WaterThermoPropsUtils.cpp
+++ b/Reaktoro/Thermodynamics/Water/WaterThermoPropsUtils.cpp
@@ -24,7 +24,6 @@ using std::sqrt;
 // Reaktoro includes
 #include <Reaktoro/Common/Exception.hpp>
 #include <Reaktoro/Common/Memoization.hpp>
-#include <Reaktoro/Thermodynamics/Water/WaterConstants.hpp>
 #include <Reaktoro/Thermodynamics/Water/WaterHelmholtzProps.hpp>
 #include <Reaktoro/Thermodynamics/Water/WaterHelmholtzPropsHGK.hpp>
 #include <Reaktoro/Thermodynamics/Water/WaterHelmholtzPropsWagnerPruss.hpp>

--- a/examples/cpp/ex-equilibrium-phreeqc-ion-exchange.cpp
+++ b/examples/cpp/ex-equilibrium-phreeqc-ion-exchange.cpp
@@ -45,27 +45,21 @@ int main()
     PhreeqcDatabase db("phreeqc.dat");
 
     // Define an aqueous phase
-    AqueousPhase aqueousphase(speciate("H O C Ca Na Mg Cl"));
-    aqueousphase.setActivityModel(chain(
+    AqueousPhase aqueous_phase(speciate("H O C Ca Na Mg Cl"));
+    aqueous_phase.setActivityModel(chain(
         ActivityModelHKF(),
         ActivityModelDrummond("CO2")
     ));
 
     // Fetch species for ion-exchange modeling
-    SpeciesList species = db.species().withAggregateState(AggregateState::IonExchange);
-
-    // Separate exchangers (e.g., X-) from exchange species (NaX, KX, NaY, NaY, ect)
-    SpeciesList exchanger_species = filter(species, [](const Species& s){ return std::abs(s.charge());});
-    SpeciesList exchange_species = filter(species, [](const Species& s){ return !s.charge();});
+    SpeciesList exchange_species = db.species().withAggregateState(AggregateState::IonExchange);
 
     // The exchanger (exchanging site) phase X with exchange species X-
-    IonExchangePhase exchanger_phase(speciesListToStringList(exchanger_species));
-
-    // Ion exchange phase (the cation exchange complex), containing species NaX, KX, CaX2 etc
-    IonExchangerPhase ionexchange_phase(speciesListToStringList(exchange_species));
+    IonExchangePhase exchange_phase(speciesListToStringList(exchange_species));
+    exchange_phase.setActivityModel(ActivityModelIonExchangeGainesThomas());
 
     // Construct the chemical system
-    ChemicalSystem system(db, aqueousphase, exchanger_phase, ionexchange_phase);
+    ChemicalSystem system(db, aqueous_phase, exchange_phase);
 
     // Specify conditions to be satisfied at the chemical equilibrium
     EquilibriumSpecs specs(system);


### PR DESCRIPTION
This PR extends a mechanism of ion exchange on the surface of the exchanger species. The Gaines--Thomas activity model is extended by non-unit  Davies or Debye-Huckel activity coefficients. These coefficients are calculated by reading the PHREEQC database with exchangers and ion exchange species and extracting corresponding to them Davies or Debye-Huckel flags and parameters. 

Tasks:

- [x] Change the type of the `extra` field from Vec<Any> to Map<String, Any>.
- [x] Introducing `Map<String, Any> m_extra` member field in `ChemicalProps` class (so that Any additional information can be evaluated and communicated between the phases).
- [x] Implement the mechanism of evaluating `AqueousMixtureState` on the level of the `ChemicalProps` (before going down to each phase), saving it in `m_extra` member-field, and passing it down to `ChemicalPropsPhase`.
- [x] Implement the extraction of the Davies or Debye-Huckel flags and parameters for each species fetched from the PHREEQC database. 
- [x] Implement cpp tests in `ActivityModelIonExchange.test.cxx` focusing on testing Davies or Debye-Huckel flags and parameters and new Davies or Debye-Huckel activity coefficients