### PR TITLE
Fix segmentation fault error in aqueous properties calculation and output

### DIFF
--- a/Reaktoro/Core/ChemicalProps.test.cxx
+++ b/Reaktoro/Core/ChemicalProps.test.cxx
@@ -25,8 +25,6 @@
 #include <Reaktoro/Core/ChemicalProps.hpp>
 using namespace Reaktoro;
 
-namespace test { extern auto createDatabase() -> Database; }
-
 TEST_CASE("Testing ChemicalProps class", "[ChemicalProps]")
 {
     const auto R = universalGasConstant;
@@ -488,7 +486,7 @@ TEST_CASE("Testing ChemicalProps class", "[ChemicalProps]")
         CHECK( props.elementAmountInPhase(3, 1) == Approx(b1[3]) );
 
         auto i = 0;
-        for(auto species : system.species())
+        for(const auto& species : system.species())
         {
             const auto name = species.name();
             const auto idx = system.species().index(name);

--- a/Reaktoro/Core/ChemicalSystem.cpp
+++ b/Reaktoro/Core/ChemicalSystem.cpp
@@ -26,6 +26,7 @@
 #include <Reaktoro/Common/Algorithms.hpp>
 #include <Reaktoro/Common/Exception.hpp>
 #include <Reaktoro/Common/StringUtils.hpp>
+#include <Reaktoro/Core/Utils.hpp>
 
 namespace Reaktoro {
 namespace detail {
@@ -48,21 +49,6 @@ auto fixDuplicateSpeciesNames(SpeciesList& specieslist)
     for(auto i = 0; i < specieslist.size(); ++i)
         if(specieslist[i].name() != speciesnames[i])
             specieslist[i] = specieslist[i].withName(speciesnames[i]);
-}
-
-/// Return the formula matrix of the species with respect to given elements.
-auto formulaMatrix(const SpeciesList& species, const ElementList& elements) -> MatrixXd
-{
-    const auto num_elements = elements.size();
-    const auto num_components = num_elements + 1;
-    const auto num_species = species.size();
-    MatrixXd A(num_components, num_species);
-    for(auto i = 0; i < num_species; ++i)
-        for(auto j = 0; j < num_elements; ++j)
-            A(j, i) = species[i].elements().coefficient(elements[j].symbol());
-    for(auto i = 0; i < num_species; ++i)
-        A(num_elements, i) = species[i].charge();
-    return A;
 }
 
 } // namespace detail
@@ -94,7 +80,7 @@ struct ChemicalSystem::Impl
     {
         species = phases.species();
         elements = species.elements();
-        formula_matrix = detail::formulaMatrix(species, elements);
+        formula_matrix = detail::assembleFormulaMatrix(species, elements);
 
         detail::fixDuplicatePhaseNames(phases);
         detail::fixDuplicateSpeciesNames(species);

--- a/Reaktoro/Core/Utils.cpp
+++ b/Reaktoro/Core/Utils.cpp
@@ -105,5 +105,19 @@ auto resolvePhaseIndex(const ChemicalSystem& system, StringOrIndex phase) -> Ind
     return std::visit([&](auto&& arg) { return resolvePhaseIndexAux(system, arg); }, phase);
 }
 
+auto assembleFormulaMatrix(const SpeciesList& species, const ElementList& elements) -> MatrixXd
+{
+    const auto num_elements = elements.size();
+    const auto num_components = num_elements + 1;
+    const auto num_species = species.size();
+    MatrixXd A(num_components, num_species);
+    for(auto i = 0; i < num_species; ++i)
+        for(auto j = 0; j < num_elements; ++j)
+            A(j, i) = species[i].elements().coefficient(elements[j].symbol());
+    for(auto i = 0; i < num_species; ++i)
+        A(num_elements, i) = species[i].charge();
+    return A;
+}
+
 } // namespace detail
 } // namespace Reaktoro

--- a/Reaktoro/Core/Utils.hpp
+++ b/Reaktoro/Core/Utils.hpp
@@ -25,6 +25,7 @@ namespace Reaktoro {
 
 // Forward declarations
 class ChemicalSystem;
+class ElementList;
 class SpeciesList;
 
 namespace detail {
@@ -47,6 +48,9 @@ auto resolveSpeciesIndex(const ChemicalSystem& system, StringOrIndex species) ->
 
 /// Resolve the index of a phase in a chemical system with given either a phase name or its index itself.
 auto resolvePhaseIndex(const ChemicalSystem& system, StringOrIndex phase) -> Index;
+
+/// Assemble the formula matrix of the list of `species` with respect to given `elements`.
+auto assembleFormulaMatrix(const SpeciesList& species, const ElementList& elements) -> MatrixXd;
 
 } // namespace detail
 } // namespace Reaktoro

--- a/Reaktoro/Core/Utils.test.cxx
+++ b/Reaktoro/Core/Utils.test.cxx
@@ -35,121 +35,116 @@ TEST_CASE("Testing CoreUtils", "[CoreUtils]")
     real actual = {};
     real expected = {};
 
-    //======================================================================
-    // Testing computeSpeciesAmount
-    //======================================================================
-    actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "mol");
-    expected = 1.0;
-    CHECK( actual == expected );
+    SECTION("Testing computeSpeciesAmount")
+    {
+        actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "mol");
+        expected = 1.0;
+        CHECK( actual == expected );
 
-    actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "mmol");
-    expected = 0.001;
-    CHECK( actual == expected );
+        actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "mmol");
+        expected = 0.001;
+        CHECK( actual == expected );
 
-    actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "kg");
-    expected = 1.0 / mmH2O;
-    CHECK( actual == Approx(expected) );
+        actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "kg");
+        expected = 1.0 / mmH2O;
+        CHECK( actual == Approx(expected) );
 
-    actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "g");
-    expected = 0.001 / mmH2O;
-    CHECK( actual == Approx(expected) );
-
-
-    //======================================================================
-    // Testing assembleFormulaMatrix for the full system
-    //======================================================================
+        actual = detail::computeSpeciesAmount(system, iH2O, 1.0, "g");
+        expected = 0.001 / mmH2O;
+        CHECK( actual == Approx(expected) );
+    }
 
     auto species = system.species();
     auto elements = system.elements();
 
     auto components_num = elements.size() + 1;
 
-    auto A = detail::assembleFormulaMatrix(species, elements);
+    SECTION("Testing assembleFormulaMatrix for the full system")
+    {
+        auto A = detail::assembleFormulaMatrix(species, elements);
 
-    CHECK( A.cols() == species.size() );
-    CHECK( A.rows() == components_num );
+        CHECK( A.cols() == species.size() );
+        CHECK( A.rows() == components_num );
 
-    MatrixXd A_system = system.formulaMatrix();
+        MatrixXd A_system = system.formulaMatrix();
 
-    for(Index i = 0; i < A.rows(); i++)
-        CHECK(A.row(i) == A_system.row(i));
+        for(Index i = 0; i < A.rows(); i++)
+            CHECK(A.row(i) == A_system.row(i));
+    }
 
-    //======================================================================
-    // Testing assembleFormulaMatrix for the aqueous phase
-    //======================================================================
+    SECTION("Testing assembleFormulaMatrix for the aqueous phase")
+    {
+        SpeciesList species_aqueous = species.withAggregateState(AggregateState::Aqueous);
 
-    SpeciesList species_aqueous = species.withAggregateState(AggregateState::Aqueous);
+        auto A_aq = detail::assembleFormulaMatrix(species_aqueous, elements);
 
-    auto A_aq = detail::assembleFormulaMatrix(species_aqueous, elements);
+        CHECK( A_aq.cols() == species_aqueous.size() );
+        CHECK( A_aq.rows() == components_num         );
 
-    CHECK( A_aq.cols() == species_aqueous.size() );
-    CHECK( A_aq.rows() == components_num         );
+        MatrixXd A_aq_expected {
+            {2,  1,  1,  2,  0,  0,  0,  0,  1,  1,  0,  0,  0,  1,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  0,  0},
+            {1,  0,  1,  0,  2,  0,  0,  0,  0,  1,  0,  0,  2,  3,  3,  0,  0,  2,  0},
+            {0,  0,  0,  0,  0,  1,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  1,  0,  0},
+            {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0},
+            {0,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  0,  0,  0,  0,  2,  2,  0,  0},
+            {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  1,  0,  0,  0},
+            {0,  1, -1,  0,  0,  1, -1,  0,  0,  0,  2,  2,  0, -1, -2,  0,  0,  0, -1}
+        };
 
-    MatrixXd A_aq_expected {
-        {2,  1,  1,  2,  0,  0,  0,  0,  1,  1,  0,  0,  0,  1,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  0,  0},
-        {1,  0,  1,  0,  2,  0,  0,  0,  0,  1,  0,  0,  2,  3,  3,  0,  0,  2,  0},
-        {0,  0,  0,  0,  0,  1,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  1,  0,  0},
-        {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0},
-        {0,  0,  0,  0,  0,  0,  1,  1,  1,  0,  0,  0,  0,  0,  0,  2,  2,  0,  0},
-        {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  1,  0,  0,  0},
-        {0,  1, -1,  0,  0,  1, -1,  0,  0,  0,  2,  2,  0, -1, -2,  0,  0,  0, -1}
-    };
+        for(Index i = 0; i < A_aq.rows(); i++)
+            CHECK(A_aq.row(i) == A_aq_expected.row(i));
+    }
 
-    for(Index i = 0; i < A.rows(); i++)
-        CHECK(A_aq.row(i) == A_aq_expected.row(i));
+    SECTION("Testing assembleFormulaMatrix for the gaseous phase")
+    {
+        SpeciesList species_gaseous = species.withAggregateState(AggregateState::Gas);
 
-     //======================================================================
-    // Testing assembleFormulaMatrix for the gaseous phase
-    //======================================================================
+        auto A_gas = detail::assembleFormulaMatrix(species_gaseous, elements);
 
-    SpeciesList species_gaseous = species.withAggregateState(AggregateState::Gas);
+        CHECK( A_gas.cols() == species_gaseous.size() );
+        CHECK( A_gas.rows() == components_num         );
 
-    auto A_gas = detail::assembleFormulaMatrix(species_gaseous, elements);
+        MatrixXd A_gas_expected {
+            {0,  0,  2,  2,  4,  0},
+            {1,  0,  0,  0,  1,  1},
+            {2,  2,  0,  1,  0,  1},
+            {0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0},
+            {0,  0,  0,  0,  0,  0},
+            };
 
-    CHECK( A_gas.cols() == species_gaseous.size() );
-    CHECK( A_gas.rows() == components_num         );
+        for(Index i = 0; i < A_gas.rows(); i++)
+            CHECK(A_gas.row(i) == A_gas_expected.row(i));
+    }
 
-    MatrixXd A_gas_expected {
-        {0,  0,  2,  2,  4,  0},
-        {1,  0,  0,  0,  1,  1},
-        {2,  2,  0,  1,  0,  1},
-        {0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0},
-        {0,  0,  0,  0,  0,  0},
-    };
+    SECTION("Testing assembleFormulaMatrix for the gaseous phase")
+    {
+        SpeciesList species_minerals = species.withAggregateState(AggregateState::Solid);
 
-    for(Index i = 0; i < A.rows(); i++)
-        CHECK(A_gas.row(i) == A_gas_expected.row(i));
+        auto A_min = detail::assembleFormulaMatrix(species_minerals, elements);
 
-    //======================================================================
-    // Testing assembleFormulaMatrix for the mineral phase
-    //======================================================================
+        CHECK( A_min.cols() == species_minerals.size() );
+        CHECK( A_min.rows() == components_num          );
 
-    SpeciesList species_minerals = species.withAggregateState(AggregateState::Solid);
+        MatrixXd A_min_expected {
+            {0,  0,  0,  0},
+            {0,  1,  1,  0},
+            {0,  3,  3,  2},
+            {1,  0,  0,  0},
+            {0,  0,  1,  0},
+            {0,  0,  0,  1},
+            {1,  0,  0,  0},
+            {0,  1,  0,  0},
+            {0,  0,  0,  0},
+            };
 
-    auto A_min = detail::assembleFormulaMatrix(species_minerals, elements);
-
-    CHECK( A_min.cols() == species_minerals.size() );
-    CHECK( A_min.rows() == components_num          );
-
-    MatrixXd A_min_expected {
-        {0,  0,  0,  0},
-        {0,  1,  1,  0},
-        {0,  3,  3,  2},
-        {1,  0,  0,  0},
-        {0,  0,  1,  0},
-        {0,  0,  0,  1},
-        {1,  0,  0,  0},
-        {0,  1,  0,  0},
-        {0,  0,  0,  0},
-    };
-
-    for(Index i = 0; i < A.rows(); i++)
-        CHECK(A_min.row(i) == A_min_expected.row(i));
+        for(Index i = 0; i < A_min.rows(); i++)
+            CHECK(A_min.row(i) == A_min_expected.row(i));
+    }
 
 }

--- a/Reaktoro/Core/Utils.test.cxx
+++ b/Reaktoro/Core/Utils.test.cxx
@@ -116,7 +116,7 @@ TEST_CASE("Testing CoreUtils", "[CoreUtils]")
             {0,  0,  0,  0,  0,  0},
             {0,  0,  0,  0,  0,  0},
             {0,  0,  0,  0,  0,  0},
-            };
+        };
 
         for(Index i = 0; i < A_gas.rows(); i++)
             CHECK(A_gas.row(i) == A_gas_expected.row(i));
@@ -141,7 +141,7 @@ TEST_CASE("Testing CoreUtils", "[CoreUtils]")
             {1,  0,  0,  0},
             {0,  1,  0,  0},
             {0,  0,  0,  0},
-            };
+        };
 
         for(Index i = 0; i < A_min.rows(); i++)
             CHECK(A_min.row(i) == A_min_expected.row(i));

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -191,7 +191,7 @@ struct AqueousProps::Impl
 
     auto elementMolalities() const -> VectorXr
     {
-        const auto E = system.phase(indexAqueousPhase(system)).elements().size();
+        const auto E = system.elements().size();
         const auto& m = aqstate.m.matrix();
         return Aaq.topRows(E) * m;
     }
@@ -388,11 +388,11 @@ auto operator<<(std::ostream& out, const AqueousProps& props) -> std::ostream&
     table.add_row({ "pE", str(props.pE()), "" });
     table.add_row({ "Eh", str(props.Eh()), "V" });
     table.add_row({ "Element Molality:" });
-    for(auto i = 0; i < me.size(); ++i)
+    for(auto i = 0; i < elements.size(); ++i)
         if(elements[i].symbol() != "H" && elements[i].symbol() != "O")
             table.add_row({ ":: " + elements[i].symbol(), str(me[i]), "molal" });
     table.add_row({ "Species Molality:" });
-    for(auto i = 0; i < ms.size(); ++i)
+    for(auto i = 0; i < species.size(); ++i)
         if(species[i].formula().str() != "H2O")
             table.add_row({ ":: " + species[i].name(), str(ms[i]), "molal" });
 

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -191,7 +191,7 @@ struct AqueousProps::Impl
 
     auto elementMolalities() const -> VectorXr
     {
-        const auto E = system.elements().size();
+        const auto E = system.phase(0).elements().size();
         const auto& m = aqstate.m.matrix();
         return Aaq.topRows(E) * m;
     }
@@ -229,12 +229,14 @@ struct AqueousProps::Impl
         const auto u = props.chemicalPotentials();
         const auto ib = echelonizer.indicesBasicVariables();
         const auto R = echelonizer.R();
+        const auto Rb = R.topRows(ib.size());
         const VectorXr ub = u(ib);
-        const auto lambda = -R.transpose() * ub;
+        const auto lambda = -Rb.transpose() * ub;
         const auto E = system.elements().size();
         const auto lambda_Z = lambda[E];
         const auto RT = universalGasConstant * T;
         const auto res = lambda_Z/(RT*ln10);
+
         return res;
     }
 

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.cpp
@@ -191,7 +191,7 @@ struct AqueousProps::Impl
 
     auto elementMolalities() const -> VectorXr
     {
-        const auto E = system.phase(0).elements().size();
+        const auto E = system.phase(indexAqueousPhase(system)).elements().size();
         const auto& m = aqstate.m.matrix();
         return Aaq.topRows(E) * m;
     }

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
@@ -19,10 +19,176 @@
 #include <catch2/catch.hpp>
 
 // Reaktoro includes
+#include <Reaktoro/Core/ChemicalSystem.hpp>
+#include <Reaktoro/Core/ChemicalState.hpp>
+#include <Reaktoro/Equilibrium/EquilibriumSolver.hpp>
+#include <Reaktoro/Equilibrium/EquilibriumResult.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
+
 using namespace Reaktoro;
+
+namespace test { extern auto createChemicalSystem() -> ChemicalSystem; }
 
 TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
 {
-    // TODO: Implement tests for AqueousProps class.
+    ChemicalSystem system = test::createChemicalSystem();
+
+    EquilibriumSolver solver(system);
+
+    AqueousProps aqprops(system);
+
+    auto phase = aqprops.phase();
+
+    const auto& species = system.species();
+    const auto& elements = system.elements();
+    const auto& aqspecies = phase.species();
+    const auto& aqelements = phase.elements();
+
+    auto num_species = species.size();
+    auto num_elements = elements.size();
+
+    SECTION("Testing correct initialization of the `AqueousProps` instance")
+    {
+        CHECK( phase.species().size()   == 19           );
+        CHECK( phase.elements().size()  == num_elements );
+        CHECK( phase.species(0).name()  == "H2O(aq)"    );
+        CHECK( phase.species(1).name()  == "H+(aq)"     );
+        CHECK( phase.species(2).name()  == "OH-(aq)"    );
+        CHECK( phase.species(3).name()  == "H2(aq)"     );
+        CHECK( phase.species(4).name()  == "O2(aq)"     );
+        CHECK( phase.species(5).name()  == "Na+(aq)"    );
+        CHECK( phase.species(6).name()  == "Cl-(aq)"    );
+        CHECK( phase.species(7).name()  == "NaCl(aq)"   );
+        CHECK( phase.species(8).name()  == "HCl(aq)"    );
+        CHECK( phase.species(9).name()  == "NaOH(aq)"   );
+        CHECK( phase.species(10).name() == "Ca++(aq)"   );
+        CHECK( phase.species(11).name() == "Mg++(aq)"   );
+        CHECK( phase.species(12).name() == "CO2(aq)"    );
+        CHECK( phase.species(13).name() == "HCO3-(aq)"  );
+        CHECK( phase.species(14).name() == "CO3--(aq)"  );
+        CHECK( phase.species(15).name() == "CaCl2(aq)"  );
+        CHECK( phase.species(16).name() == "MgCl2(aq)"  );
+        CHECK( phase.species(17).name() == "SiO2(aq)"   );
+        CHECK( phase.species(18).name() == "e-(aq)"     );
+    }
+
+    const real T = 25.0; // celsius
+    const real P = 1.0;  // bar
+
+    SECTION("Testing when species have zero amounts")
+    {
+        const ArrayXr n = ArrayXr::Zero(num_species);
+
+        ChemicalState state(system);
+        state.setTemperature(T);
+        state.setPressure(P);
+        state.setSpeciesAmounts(n);
+
+        CHECK_THROWS(aqprops.update(state));
+    }
+
+    SECTION("Testing when species have nonzero amounts")
+    {
+        ArrayXd n = ArrayXd::Ones(num_species);
+
+        ChemicalState state(system);
+        state.setTemperature(T, "celsius");
+        state.setPressure(P, "bar");
+        state.setSpeciesAmounts(n);
+
+        aqprops.update(state);
+
+        // Check values of aqueous properties
+        CHECK( aqprops.pressure()                    == Approx(P*1e5)        );
+        CHECK( aqprops.temperature()                 == Approx(T + 273.15)   );
+        CHECK( aqprops.Eh()                          == Approx(-0.000671794) );
+        CHECK( aqprops.pH()                          == Approx(-0.0205718)   );
+        CHECK( aqprops.ionicStrength()               == Approx(499.576)      );
+        CHECK( aqprops.ionicStrengthEffective()      == Approx(499.576)      );
+        CHECK( aqprops.ionicStrengthStoichiometric() == Approx(999.152)      );
+
+        // Check molalities of all species
+        for (Index i = 0; i < aqspecies.size() ; i++)
+            CHECK( aqprops.speciesMolalities()[i] == Approx(55.5085) );
+
+        // Check molalities of all elements
+        CHECK( aqprops.elementMolality("H")  == Approx(499.576) );
+        CHECK( aqprops.elementMolality("C")  == Approx(166.525) );
+        CHECK( aqprops.elementMolality("O")  == Approx(832.627) );
+        CHECK( aqprops.elementMolality("Na") == Approx(166.525) );
+        CHECK( aqprops.elementMolality("Mg") == Approx(111.017) );
+        CHECK( aqprops.elementMolality("Si") == Approx(55.5085) );
+        CHECK( aqprops.elementMolality("Cl") == Approx(388.559) );
+        CHECK( aqprops.elementMolality("Ca") == Approx(111.017) );
+    }
+
+    SECTION("Testing when state is a brine")
+    {
+        ChemicalState state(system);
+        state.setTemperature(T, "celsius");
+        state.setPressure(P, "bar");
+        state.setSpeciesMass("H2O(aq)" , 1.00, "kg");
+        state.setSpeciesMass("Na+(aq)" , 2.05, "mg");
+        state.setSpeciesMass("Ca++(aq)", 1.42, "mg");
+        state.setSpeciesMass("Mg++(aq)", 0.39, "mg");
+        state.setSpeciesMass("Cl-(aq)" , 3.47, "mg");
+
+        EquilibriumResult result = solver.solve(state);
+
+        aqprops.update(state);
+
+        // Check values of aqueous properties
+        CHECK( aqprops.pressure()                    == Approx(P*1e5)        );
+        CHECK( aqprops.temperature()                 == Approx(T + 273.15)   );
+        CHECK( aqprops.ionicStrength()               == Approx(27.2725)      );
+        CHECK( aqprops.Eh()                          == Approx(-0.000754246) );
+        CHECK( aqprops.pH()                          == Approx(-0.0605375)   );
+        CHECK( aqprops.ionicStrengthEffective()      == Approx(27.2725)      );
+        CHECK( aqprops.ionicStrengthStoichiometric() == Approx(27.273)       );
+
+        // Check molalities of all species
+        CHECK( aqprops.speciesMolality("H2O(aq)"  ) == Approx(55.5085)     );
+        CHECK( aqprops.speciesMolality("H+(aq)"   ) == Approx(27.2723)     );
+        CHECK( aqprops.speciesMolality("OH-(aq)"  ) == Approx(27.2723)     );
+        CHECK( aqprops.speciesMolality("H2(aq)"   ) == Approx(44.0212)     );
+        CHECK( aqprops.speciesMolality("O2(aq)"   ) == Approx(22.0106)     );
+        CHECK( aqprops.speciesMolality("Na+(aq)"  ) == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("Cl-(aq)"  ) == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("NaCl(aq)" ) == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("HCl(aq)"  ) == Approx(0.000223584) );
+        CHECK( aqprops.speciesMolality("NaOH(aq)" ) == Approx(0.000203703) );
+        CHECK( aqprops.speciesMolality("Ca++(aq)" ) == Approx(8.09398e-05) );
+        CHECK( aqprops.speciesMolality("Mg++(aq)" ) == Approx(3.6657e-05)  );
+        CHECK( aqprops.speciesMolality("CO2(aq)"  ) == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("HCO3-(aq)") == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("CO3--(aq)") == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("CaCl2(aq)") == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("MgCl2(aq)") == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("SiO2(aq)" ) == Approx(2.28438e-16) );
+        CHECK( aqprops.speciesMolality("e-(aq)"   ) == Approx(2.28438e-16) );
+
+        // Check molalities of all elements
+        CHECK( aqprops.elementMolality("H")  == Approx(253.604)     );
+        CHECK( aqprops.elementMolality("C")  == Approx(6.85313e-16) );
+        CHECK( aqprops.elementMolality("O")  == Approx(126.802)     );
+        CHECK( aqprops.elementMolality("Na") == Approx(0.000203703) );
+        CHECK( aqprops.elementMolality("Mg") == Approx(3.6657e-05)  );
+        CHECK( aqprops.elementMolality("Si") == Approx(2.28438e-16) );
+        CHECK( aqprops.elementMolality("Cl") == Approx(0.000223584) );
+        CHECK( aqprops.elementMolality("Ca") == Approx(8.09398e-05) );
+
+        // Test convenience methods species and element molalities
+        for(const auto& s : aqspecies)
+        {
+            const auto name = s.name();
+            const auto idx = aqspecies.index(name);
+            CHECK( aqprops.speciesMolality(name)     == Approx(aqprops.speciesMolalities()[idx]) );
+        }
+        for(const auto& e : aqelements)
+        {
+            const auto symbol = e.symbol();
+            const auto idx = aqelements.index(symbol);
+            CHECK( aqprops.elementMolality(symbol)     == Approx(aqprops.elementMolalities()[idx]) );
+        }
+    }
 }

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
@@ -19,10 +19,10 @@
 #include <catch2/catch.hpp>
 
 // Reaktoro includes
-#include <Reaktoro/Core/ChemicalSystem.hpp>
 #include <Reaktoro/Core/ChemicalState.hpp>
-#include <Reaktoro/Equilibrium/EquilibriumSolver.hpp>
+#include <Reaktoro/Core/ChemicalSystem.hpp>
 #include <Reaktoro/Equilibrium/EquilibriumResult.hpp>
+#include <Reaktoro/Equilibrium/EquilibriumSolver.hpp>
 #include <Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp>
 
 using namespace Reaktoro;
@@ -108,7 +108,7 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
         CHECK( aqprops.ionicStrengthStoichiometric() == Approx(999.152)      );
 
         // Check molalities of all species
-        for (Index i = 0; i < aqspecies.size() ; i++)
+        for(auto i = 0; i < aqspecies.size(); i++)
             CHECK( aqprops.speciesMolalities()[i] == Approx(55.5085) );
 
         // Check molalities of all elements
@@ -184,6 +184,7 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
             const auto idx = aqspecies.index(name);
             CHECK( aqprops.speciesMolality(name)     == Approx(aqprops.speciesMolalities()[idx]) );
         }
+
         for(const auto& e : aqelements)
         {
             const auto symbol = e.symbol();

--- a/examples/cpp/ex-equilibrium-phreeqc-ion-exchange.cpp
+++ b/examples/cpp/ex-equilibrium-phreeqc-ion-exchange.cpp
@@ -91,5 +91,14 @@ int main()
     // Output the chemical state to a text file
     solutionstate.output("state.txt");
 
+    // Compute chemical and thermodynamic properties at equilibrium state
+    ChemicalProps props(solutionstate);
+
+    // Compute chemical properties for the aqueous phase at equilibrium state
+    AqueousProps aqprops(props);
+
+    // Output these properties
+    aqprops.output("aqprops.txt");
+
     return 0;
 }


### PR DESCRIPTION
Fix segmentation fault error generated during the call

~~~c++
AqueousProps aqprops(props);
td::cout << aqprops << std::endl;
~~~

on the stage of pE calculation and during the output.

Tasks:

- [x] Fix segmentation fault error during the call `pE()`.
- [x] Fix segmentation fault error during the call of `<<operator()`.

New Tasks: 
- [x] Implement tests for `assembleFormulaMatrix`, from `Core/Utils.hpp`, in `Core/Utils.test.cxx`
- [x] Implement tests for `AqueousProps` in `AqueousProps.tests.cxx`

**Note:** 
- For the `assembleFormulaMatrix` test, check `ChemicalSystem.test.cxx`, the end of the file.
- For the `AqueousProps` test, also check `ChemicalSystem.test.cxx` to see the line `ChemicalSystem system = test::createChemicalSystem();` for a mock `ChemicalSystem` object.