### PR TITLE
Add missing ln(xw) term in Debye-Huckel model 

### DIFF
--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.cpp
@@ -391,8 +391,8 @@ auto activityModelDebyeHuckel(const SpeciesList& species, ActivityModelDebyeHuck
             // Update the sigma parameter of the current ion
             const real sigma = (aions[i] != 0.0) ? 3.0*pow(Lambda - 1, -3) * ((Lambda - 1)*(Lambda - 3) + 2*log(Lambda)) : real(2.0);
 
-            // Calculate the ln activity coefficient of the current charged species
-            ln_g[ispecies] = ln10 * (-A*z*z*sqrtI/Lambda + bions[i]*I);
+            // Calculate the ln activity coefficient of the current charged species (in molal scale)
+            ln_g[ispecies] = ln10 * (-A*z*z*sqrtI/Lambda + bions[i]*I) + ln_xw;
 
             // Calculate the ln activity of the current charged species
             ln_a[ispecies] = ln_g[ispecies] + ln_m[ispecies];

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDebyeHuckel.test.cxx
@@ -278,18 +278,18 @@ TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.92756900) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.72591900) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.56403300) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.71947800) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.59408700) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.24441000) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.63889300) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.17859700) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.27351000) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.27351000) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.27351000) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.27351000) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -305,18 +305,18 @@ TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.92756900) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.72591900) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.56403300) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.71947800) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.59408700) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.24441000) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.63889300) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.17859700) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.27351000) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.27351000) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.27351000) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.27351000) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -332,18 +332,18 @@ TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9265452628) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7197968710) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.5985609831) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.92712500) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.72591900) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.56403300) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.70332500) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.58486300) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.24441000) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.63889300) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.17859700) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.27351000) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.27351000) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.27351000) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.27351000) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -359,18 +359,18 @@ TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9209334298) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.6004257058) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.5513105763) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2047658694) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6004257058) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1489680248) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.92151000) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.72591900) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.56403300) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.58668600) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.53869400) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.20008000) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.58668600) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.14555900) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.27351000) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.27351000) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.27351000) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.27351000) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -386,18 +386,18 @@ TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.8469626739) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.3025737114) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.3025737114) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.3025737114) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.3025737114) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.0083815583) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.3025737114) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.0083815583) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.84749300) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.29565000) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.29565000) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.29565000) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.29565000) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.00818975) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.29565000) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.00818975) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.27351000) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.27351000) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.27351000) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.27351000) ); // NaOH
 
         checkActivities(x, props);
     }

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDrummond.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDrummond.test.cxx
@@ -78,18 +78,18 @@ TEST_CASE("Testing ActivityModelDrummond", "[ActivityModelDrummond]")
         ActivityModel fn = ActivityModelDrummond("CO2")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2653968875) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.265400) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.273510) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -99,18 +99,18 @@ TEST_CASE("Testing ActivityModelDrummond", "[ActivityModelDrummond]")
         ActivityModel fn = ActivityModelDrummond("NaCl")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2653968875) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.273510) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.265400) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelDuanSun.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelDuanSun.test.cxx
@@ -78,18 +78,18 @@ TEST_CASE("Testing ActivityModelDuanSun", "[ActivityModelDuanSun]")
         ActivityModel fn = ActivityModelDuanSun("CO2")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.1585365027) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.158540) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.273510) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -99,18 +99,18 @@ TEST_CASE("Testing ActivityModelDuanSun", "[ActivityModelDuanSun]")
         ActivityModel fn = ActivityModelDuanSun("NaCl")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.1585365027) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.273510) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.158540) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelRumpf.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelRumpf.test.cxx
@@ -78,18 +78,18 @@ TEST_CASE("Testing ActivityModelRumpf", "[ActivityModelRumpf]")
         ActivityModel fn = ActivityModelRumpf("CO2")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.1689628021) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.168960) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.273510) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }
@@ -99,18 +99,18 @@ TEST_CASE("Testing ActivityModelRumpf", "[ActivityModelRumpf]")
         ActivityModel fn = ActivityModelRumpf("NaCl")(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(1.2735057287) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.1689628021) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(1.273510) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.168960) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }

--- a/Reaktoro/Thermodynamics/Aqueous/ActivityModelSetschenow.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/ActivityModelSetschenow.test.cxx
@@ -78,18 +78,18 @@ TEST_CASE("Testing ActivityModelSetschenow", "[ActivityModelSetschenow]")
         ActivityModel fn = ActivityModelSetschenow("CO2", 0.5)(species);
         fn(props, {T, P, x});
 
-        CHECK( exp(props.ln_g[0])  == Approx(0.9269890137) ); // H2O
-        CHECK( exp(props.ln_g[1])  == Approx(0.7429198411) ); // H+
-        CHECK( exp(props.ln_g[2])  == Approx(0.5772424599) ); // OH-
-        CHECK( exp(props.ln_g[3])  == Approx(0.7363279956) ); // Na+
-        CHECK( exp(props.ln_g[4])  == Approx(0.6080001197) ); // Cl-
-        CHECK( exp(props.ln_g[5])  == Approx(0.2501338902) ); // Ca++
-        CHECK( exp(props.ln_g[6])  == Approx(0.6538562298) ); // HCO3-
-        CHECK( exp(props.ln_g[7])  == Approx(0.1827801645) ); // CO3--
-        CHECK( exp(props.ln_g[8])  == Approx(3.3496892120) ); // CO2
-        CHECK( exp(props.ln_g[9])  == Approx(1.2735057287) ); // NaCl
-        CHECK( exp(props.ln_g[10]) == Approx(1.2735057287) ); // HCl
-        CHECK( exp(props.ln_g[11]) == Approx(1.2735057287) ); // NaOH
+        CHECK( exp(props.ln_g[0])  == Approx(0.927569) ); // H2O
+        CHECK( exp(props.ln_g[1])  == Approx(0.725919) ); // H+
+        CHECK( exp(props.ln_g[2])  == Approx(0.564033) ); // OH-
+        CHECK( exp(props.ln_g[3])  == Approx(0.719478) ); // Na+
+        CHECK( exp(props.ln_g[4])  == Approx(0.594087) ); // Cl-
+        CHECK( exp(props.ln_g[5])  == Approx(0.244410) ); // Ca++
+        CHECK( exp(props.ln_g[6])  == Approx(0.638893) ); // HCO3-
+        CHECK( exp(props.ln_g[7])  == Approx(0.178597) ); // CO3--
+        CHECK( exp(props.ln_g[8])  == Approx(3.349690) ); // CO2
+        CHECK( exp(props.ln_g[9])  == Approx(1.273510) ); // NaCl
+        CHECK( exp(props.ln_g[10]) == Approx(1.273510) ); // HCl
+        CHECK( exp(props.ln_g[11]) == Approx(1.273510) ); // NaOH
 
         checkActivities(x, props);
     }


### PR DESCRIPTION
This PR adds a missing `ln(xw)` term in the activity coefficients computed with the Debye-Huckel model.

Thanks to @volpatto for pointing out to this!