### PR TITLE
Improvements in saturation indices computation in `AqueousProps`

### DIFF
--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
@@ -137,17 +137,38 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
         CHECK( aqprops.elementMolality("Cl") == Approx(388.559) );
         CHECK( aqprops.elementMolality("Ca") == Approx(111.017) );
 
-        // Set activity model of gases to that of Peng-Robinson. Expected
-        // values below for lnOmega correspond to this option, and not to the
-        // default option of ideal gas activity model!
-        aqprops.setActivityModel("CO2(g)", ActivityModelPengRobinson());
-        aqprops.setActivityModel("O2(g)" , ActivityModelPengRobinson());
-        aqprops.setActivityModel("H2(g)" , ActivityModelPengRobinson());
-        aqprops.setActivityModel("H2O(g)", ActivityModelPengRobinson());
-        aqprops.setActivityModel("CH4(g)", ActivityModelPengRobinson());
-        aqprops.setActivityModel("CO(g)" , ActivityModelPengRobinson());
+        // Check saturation indices of the non-aqueous species
+        auto lnOmega = aqprops.saturationIndicesLn();
 
-        const auto lnOmega = aqprops.saturationIndicesLn();
+        CHECK( lnOmega[0]  == Approx(-1.474090) );
+        CHECK( lnOmega[1]  == Approx(-1.447940) );
+        CHECK( lnOmega[2]  == Approx(-1.447940) );
+        CHECK( lnOmega[3]  == Approx(-1.421790) );
+        CHECK( lnOmega[4]  == Approx(-1.421790) );
+        CHECK( lnOmega[5]  == Approx(-1.500230) );
+        CHECK( lnOmega[6]  == Approx(-9.050290) );
+        CHECK( lnOmega[7]  == Approx(-9.050290) );
+        CHECK( lnOmega[8]  == Approx(-9.050290) );
+        CHECK( lnOmega[9]  == Approx( 0.102009) );
+        CHECK( lnOmega[10] == Approx(-9.050290) );
+
+        // Set activity model of gases to that of Peng-Robinson and for solids,
+        // ideal model. Note: the reason the saturation indices below for
+        // solids differ from those above is because the mock chemical system
+        // does consider unit activities for the solid species!
+        aqprops.setActivityModel("CO2(g)"       , ActivityModelPengRobinson());
+        aqprops.setActivityModel("O2(g)"        , ActivityModelPengRobinson());
+        aqprops.setActivityModel("H2(g)"        , ActivityModelPengRobinson());
+        aqprops.setActivityModel("H2O(g)"       , ActivityModelPengRobinson());
+        aqprops.setActivityModel("CH4(g)"       , ActivityModelPengRobinson());
+        aqprops.setActivityModel("CO(g)"        , ActivityModelPengRobinson());
+        aqprops.setActivityModel("NaCl(s)"      , ActivityModelIdealSolution(StateOfMatter::Solid));
+        aqprops.setActivityModel("CaCO3(s)"     , ActivityModelIdealSolution(StateOfMatter::Solid));
+        aqprops.setActivityModel("MgCO3(s)"     , ActivityModelIdealSolution(StateOfMatter::Solid));
+        aqprops.setActivityModel("CaMg(CO3)2(s)", ActivityModelIdealSolution(StateOfMatter::Solid));
+        aqprops.setActivityModel("SiO2(s)"      , ActivityModelIdealSolution(StateOfMatter::Solid));
+
+        lnOmega = aqprops.saturationIndicesLn();
 
         CHECK( lnOmega[0]  == Approx(0.031383400) );
         CHECK( lnOmega[1]  == Approx(0.052984200) );


### PR DESCRIPTION
This PR improves the recently added capability of computing saturation indices of non-aqueous species in `AqueousProps`. With this PR, chemical potentials available in `ChemicalProps` are used in saturation index calculation if the non-aqueous species is present in the system. In this way, perfect zero stability index is obtained for species that are in equilibrium with the aqueous solution, as seen in the table below for species `CO2(g)`, `H2O(g)`, and `Quartz`:

~~~text
+-----------------------------------+------------+-------+
| Property                          |      Value |  Unit |
+-----------------------------------+------------+-------+
| Temperature                       |   333.1500 |     K |
| Pressure                          |    15.1988 |   bar |
| Ionic Strength (Effective)        |     1.0263 | molal |
| Ionic Strength (Stoichiometric)   |     1.0292 | molal |
| pH                                |     4.9176 |       |
| pE                                |    -0.5028 |       |
| Eh                                |    -0.0332 |     V |
| Element Molality:                 |            |       |
| :: C                              | 2.1424e-01 | molal |
| :: Na                             | 1.0004e+00 | molal |
| :: Si                             | 2.8155e-04 | molal |
| :: Cl                             | 1.0004e+00 | molal |
| :: Ca                             | 9.9945e-03 | molal |
| Species Molality:                 |            |       |
| :: CO3-2                          | 6.4481e-07 | molal |
| :: H+                             | 1.5051e-05 | molal |
| :: CO2                            | 1.9424e-01 | molal |
| :: (CO2)2                         | 1.0004e-16 | molal |
| :: HCO3-                          | 1.6442e-02 | molal |
| :: CH4                            | 1.0004e-16 | molal |
| :: Ca+2                           | 9.4377e-03 | molal |
| :: CaCO3                          | 3.9717e-07 | molal |
| :: CaHCO3+                        | 5.5643e-04 | molal |
| :: CaOH+                          | 4.6059e-11 | molal |
| :: Cl-                            | 1.0004e+00 | molal |
| :: H2                             | 1.0004e-16 | molal |
| :: H4SiO4                         | 2.8153e-04 | molal |
| :: H2SiO4-2                       | 1.1055e-14 | molal |
| :: H3SiO4-                        | 2.0567e-08 | molal |
| :: Na+                            | 9.9737e-01 | molal |
| :: NaCO3-                         | 7.5617e-06 | molal |
| :: NaHCO3                         | 2.9885e-03 | molal |
| :: OH-                            | 1.3304e-08 | molal |
| :: NaOH                           | 1.0004e-16 | molal |
| :: O2                             | 1.0004e-16 | molal |
| Saturation Indices (log base 10): |            |       |
| :: CH4(g)                         |     1.5257 |     - |
| :: CO2(g)                         |     0.0000 |     - |
| :: H2(g)                          |     5.5218 |     - |
| :: H2O(g)                         |     0.0000 |     - |
| :: O2(g)                          |   -40.4867 |     - |
| :: Aragonite :: CaCO3             |    -1.4245 |     - |
| :: Calcite :: CaCO3               |    -1.3039 |     - |
| :: Chalcedony :: SiO2             |    -0.3316 |     - |
| :: Halite :: NaCl                 |    -1.9594 |     - |
| :: Quartz :: SiO2                 |     0.0000 |     - |
| :: SiO2(a)                        |    -1.0599 |     - |
+-----------------------------------+------------+-------+
~~~

Compare these new saturation indices with the previous ones (in which saturation indices of `CO2(g)` and `H2O(g)` are not zero, despite the solution being in equilibrium with these gases):

~~~text
| Saturation Indices (log base 10): |            |       |
| :: CH4(g)                         |   -14.1826 |     - |
| :: CO2(g)                         |    -0.0322 |     - |
| :: H2(g)                          |   -10.1580 |     - |
| :: H2O(g)                         |    -1.9030 |     - |
| :: O2(g)                          |   -56.1834 |     - |
| :: Aragonite :: CaCO3             |    -1.4245 |     - |
| :: Calcite :: CaCO3               |    -1.3039 |     - |
| :: Chalcedony :: SiO2             |    -0.3316 |     - |
| :: Halite :: NaCl                 |    -1.9594 |     - |
| :: Quartz :: SiO2                 |     0.0000 |     - |
| :: SiO2(a)                        |    -1.0599 |     - |
+-----------------------------------+------------+-------+
~~~

**Note:** This change, which brings conformance of zero saturation indices for non-aqueous species in equilibrium with the aqueous solution, has its side-effects, however. In this chemical state, gases `CH4(g)` and `H2(g)` exist at tiny amounts (1e-16) because the equilibrium solver determined that they should be attached to their lower bounds (as increasing their amounts cause the overall Gibbs energy of the system to increase). However, the saturation indices above for these two gases indicate that the solution is saturated with respect to them, implying that these gases could form. This is not the case, because as stated before, increasing their amounts will make the system less stable (higher Gibbs energy). 

*Thus, the analysis of saturation indices of non-aqueous species existing in tiny amounts (unstable species) should be done with care.* 

----

For those gases to have zero saturation indices, we would have to add a bit of them in the initial state and then equilibrate it. For example, the script below:

~~~py
from reaktoro import *

db = PhreeqcDatabase("phreeqc.dat")

solution = AqueousPhase(speciate("H O Na Cl C Ca Si"))
solution.setActivityModel(ActivityModelPitzerHMW())

gases = GaseousPhase()
gases.setActivityModel(ActivityModelPengRobinson())

minerals = MineralPhases()

system = ChemicalSystem(db, solution, gases, minerals)

state = ChemicalState(system)
state.temperature(60.0, "celsius")
state.pressure(15.0, "atm")
state.set("H2O"    , 1.0, "kg")
state.set("Na+"    , 1.0, "mol")
state.set("Cl-"    , 1.0, "mol")
state.set("CO2"    , 0.7, "mol")
state.set("Calcite", 1.0, "g")
state.set("Quartz" , 1.0, "g")
state.set("H2(g)"  , 1.0, "umol")
state.set("CH4(g)"  , 1.0, "umol")

equilibrate(state)

aprops = AqueousProps(state)

print(aprops)
~~~

produces the following table instead:

~~~text
| Saturation Indices (log base 10): |            |       |
| :: CH4(g)                         |     0.0000 |     - |
| :: CO2(g)                         |     0.0000 |     - |
| :: H2(g)                          |     0.0000 |     - |
| :: H2O(g)                         |     0.0000 |     - |
| :: O2(g)                          |   -44.7658 |     - |
| :: Aragonite :: CaCO3             |    -1.4245 |     - |
| :: Calcite :: CaCO3               |    -1.3039 |     - |
| :: Chalcedony :: SiO2             |    -0.3316 |     - |
| :: Halite :: NaCl                 |    -1.9594 |     - |
| :: Quartz :: SiO2                 |     0.0000 |     - |
| :: SiO2(a)                        |    -1.0599 |     - |
+-----------------------------------+------------+-------+
~~~

which now shows both `CH4(g)` and `H2(g)` in equilibrium with the solution (zero saturation index).