### PR TITLE
Override ThermoFun standard molar volumes for gases: set them to zero 

### DIFF
--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.cpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.cpp
@@ -38,9 +38,16 @@ namespace {
 /// Return the standard thermodynamic property function of a species with given name.
 auto createStandardThermoModel(const ThermoFunEngine& engine, const String& species) -> StandardThermoModel
 {
+    const auto& substances = engine.database().mapSubstances();
+    const auto it = substances.find(species);
+
+    errorif(it == substances.end(), "Expecting a species name that exists in the ThermoFun database, but got `", species, "` instead.");
+
+    const auto substance = it->second;
+
     return [=](real T, real P) -> StandardThermoProps
     {
-        return engine.props(T, P, species);
+        return engine.props(T, P, substance);
     };
 }
 

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.py
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.py
@@ -87,7 +87,7 @@ def testThermoFunDatabase():
     props = species.standardThermoProps(T, P)
     assert props.G0[0]  == pytest.approx(-3.943510e+05)
     assert props.H0[0]  == pytest.approx(-3.935472e+05)
-    assert props.V0[0]  == pytest.approx( 2.466434e-02)
+    assert props.V0[0]  == pytest.approx( 0.0000000000)
     assert props.Cp0[0] == pytest.approx( 3.710812e+01)
 
     #-------------------------------------------------------------------

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.test.cxx
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.test.cxx
@@ -118,7 +118,7 @@ TEST_CASE("Testing ThermoFunDatabase", "[ThermoFunDatabase]")
     props = species.standardThermoProps(T, P);
     CHECK( props.G0  == Approx(-3.943510e+05) );
     CHECK( props.H0  == Approx(-3.935472e+05) );
-    CHECK( props.V0  == Approx( 2.466434e-02) );
+    CHECK( props.V0  == Approx(0.00000000000) );
     CHECK( props.VT0 == Approx(0.00000000000) );
     CHECK( props.VP0 == Approx(0.00000000000) );
     CHECK( props.Cp0 == Approx( 3.710812e+01) );

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.cpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.cpp
@@ -33,6 +33,11 @@ auto convertProps(const ThermoFun::ThermoPropertiesSubstance& other, const Therm
     converted.H0  = other.enthalpy.val;
     converted.V0  = other.volume.val * 1.0e-05; // from J/bar to m3/mol
     converted.Cp0 = other.heat_capacity_cp.val;
+
+    // Reaktoro expects zero standard molar volumes for gases.
+    if(substance.aggregateState() == ThermoFun::AggregateState::GAS)
+        converted.V0 = 0.0;
+
     return converted;
 }
 
@@ -76,7 +81,6 @@ struct ThermoFunEngine::Impl
         return convertProps(props, substance);
     }
 };
-
 
 ThermoFunEngine::ThermoFunEngine(const ThermoFun::Database& database)
 : pimpl(new Impl(database))

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.hpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.hpp
@@ -22,7 +22,7 @@
 #include <Reaktoro/Core/StandardThermoProps.hpp>
 
 // Forward declaration of ThermoFun classes
-namespace ThermoFun { class Database; }
+namespace ThermoFun { class Database; class Substance; }
 
 namespace Reaktoro {
 
@@ -39,6 +39,9 @@ public:
 
     /// Return the standard thermodynamic properties of a chemical species with given name.
     auto props(const real& T, const real& P, const String& species) const -> StandardThermoProps;
+
+    /// Return the standard thermodynamic properties of a chemical species with given ThermoFun::Substance object.
+    auto props(const real& T, const real& P, const ThermoFun::Substance& substance) const -> StandardThermoProps;
 
 private:
     struct Impl;


### PR DESCRIPTION
In Reaktoro, the standard molar volumes of gases are expected to be zero. This is a common convention in the literature. ThermoFun adopts the convention that these properties are identical to ideal gas molar volumes, <img src="https://render.githubusercontent.com/render/math?math=V^\circ_i=RT/P">.

This PR sets the standard molar volumes of gases computed by ThermoFun to zero to ensure the zero convention for these properties.

This issue was raised by @dover22 via Gitter. Thanks!