### PR TITLE
Implement support to standard heat capacities for reactions 

### DIFF
--- a/Reaktoro/Core/FormationReaction.cpp
+++ b/Reaktoro/Core/FormationReaction.cpp
@@ -89,15 +89,17 @@ struct FormationReaction::Impl
             // Compute finally the standard thermodynamic properties of the product species
             StandardThermoProps props;
 
-            props.V0 = V0p;
-            props.G0 = rxnprops.dG0; // G0 = dG0 + sum(vr * G0r)
-            props.H0 = rxnprops.dH0; // H0 = dH0 + sum(vr * H0r)
+            props.V0  = V0p;
+            props.G0  = rxnprops.dG0;  // G0  = ΔG0  + sum(vr * G0r)
+            props.H0  = rxnprops.dH0;  // H0  = ΔH0  + sum(vr * H0r)
+            props.Cp0 = rxnprops.dCp0; // Cp0 = ΔCp0 + sum(vr * Cp0r)
             for(auto i = 0; i < num_reactants; ++i)
             {
                 const auto& coeff = reactants[i].second;
                 const auto& reactantprops = reactants_props[i];
-                props.G0 += coeff * reactantprops.G0;
-                props.H0 += coeff * reactantprops.H0;
+                props.G0  += coeff * reactantprops.G0;
+                props.H0  += coeff * reactantprops.H0;
+                props.Cp0 += coeff * reactantprops.Cp0;
             }
             return props;
         };

--- a/Reaktoro/Core/FormationReaction.test.cxx
+++ b/Reaktoro/Core/FormationReaction.test.cxx
@@ -42,6 +42,10 @@ TEST_CASE("Testing FormationReaction class", "[FormationReaction]")
     const auto dH0_D = 234.5;
     const auto dH0_E = 345.6;
 
+    const auto dCp0_C =   0.0;
+    const auto dCp0_D = 345.6;
+    const auto dCp0_E = 457.7;
+
     const auto V0_C = 16.324;
     const auto V0_D = 17.435;
     const auto V0_E = 18.546;
@@ -72,8 +76,9 @@ TEST_CASE("Testing FormationReaction class", "[FormationReaction]")
                 .withReactionThermoModel(
                     [=](ReactionThermoProps& res, ReactionThermoArgs args) {
                         const auto& [T, P, dV0] = args;
-                        res.dG0 = -R*T*ln10*lgK_D;
-                        res.dH0 = dH0_D;
+                        res.dG0  = -R*T*ln10*lgK_D;
+                        res.dH0  = dH0_D;
+                        res.dCp0 = dCp0_D;
                         return res;
                     })
             );
@@ -87,8 +92,9 @@ TEST_CASE("Testing FormationReaction class", "[FormationReaction]")
                 .withReactionThermoModel(
                     [=](ReactionThermoProps& res, ReactionThermoArgs args) {
                         const auto& [T, P, dV0] = args;
-                        res.dG0 = -R*T*ln10*lgK_E;
-                        res.dH0 = dH0_E;
+                        res.dG0  = -R*T*ln10*lgK_E;
+                        res.dH0  = dH0_E;
+                        res.dCp0 = dCp0_E;
                         return res;
                     })
             );
@@ -153,9 +159,16 @@ TEST_CASE("Testing FormationReaction class", "[FormationReaction]")
     const auto H0_D = H0_B + 3*H0_C + dH0_D;
     const auto H0_E = H0_C - 2*H0_D + dH0_E;
 
+    const auto Cp0_A = 0.0;
+    const auto Cp0_B = 0.0;
+    const auto Cp0_C = Cp0_A + 2*Cp0_B + dCp0_C;
+    const auto Cp0_D = Cp0_B + 3*Cp0_C + dCp0_D;
+    const auto Cp0_E = Cp0_C - 2*Cp0_D + dCp0_E;
+
     // Convenient functions that evaluate a reaction thermo prop at given temperature and pressure
-    auto G0 = [](auto reaction, auto T, auto P) { return reaction.createStandardThermoModel()(T, P).G0; };
-    auto H0 = [](auto reaction, auto T, auto P) { return reaction.createStandardThermoModel()(T, P).H0; };
+    auto G0  = [](auto reaction, auto T, auto P) { return reaction.createStandardThermoModel()(T, P).G0;  };
+    auto H0  = [](auto reaction, auto T, auto P) { return reaction.createStandardThermoModel()(T, P).H0;  };
+    auto Cp0 = [](auto reaction, auto T, auto P) { return reaction.createStandardThermoModel()(T, P).Cp0; };
 
     REQUIRE( G0(C.reaction(), T, P)  == Approx(G0_C) );
     REQUIRE( G0(D.reaction(), T, P)  == Approx(G0_D) );
@@ -164,4 +177,8 @@ TEST_CASE("Testing FormationReaction class", "[FormationReaction]")
     REQUIRE( H0(C.reaction(), T, P)  == Approx(H0_C) );
     REQUIRE( H0(D.reaction(), T, P)  == Approx(H0_D) );
     REQUIRE( H0(E.reaction(), T, P)  == Approx(H0_E) );
+
+    REQUIRE( Cp0(C.reaction(), T, P)  == Approx(Cp0_C) );
+    REQUIRE( Cp0(D.reaction(), T, P)  == Approx(Cp0_D) );
+    REQUIRE( Cp0(E.reaction(), T, P)  == Approx(Cp0_E) );
 }

--- a/Reaktoro/Core/ReactionThermoProps.hpp
+++ b/Reaktoro/Core/ReactionThermoProps.hpp
@@ -33,10 +33,13 @@ namespace Reaktoro {
 struct ReactionThermoProps
 {
     /// The standard molar Gibbs energy change @f$\Delta G^{\circ}@f$ of the reaction (in J/mol).
-    real dG0 = {};
+    real dG0;
 
     /// The standard molar enthalpy change @f$\Delta H^{\circ}@f$ of the reaction (in J/mol).
-    real dH0 = {};
+    real dH0;
+
+    /// The standard molar isobaric heat capacity change @f$\Delta C_{P}^{\circ}@f$ of the reaction (in J/(mol·K)).
+    real dCp0;
 };
 
 /// The arguments in a ReactionThermoModel function object.

--- a/Reaktoro/Core/ReactionThermoProps.py.cxx
+++ b/Reaktoro/Core/ReactionThermoProps.py.cxx
@@ -27,8 +27,9 @@ void exportReactionThermoProps(py::module& m)
 {
     py::class_<ReactionThermoProps>(m, "ReactionThermoProps")
         .def(py::init<>())
-        .def_readwrite("dG0", &ReactionThermoProps::dG0)
-        .def_readwrite("dH0", &ReactionThermoProps::dH0)
+        .def_readwrite("dG0" , &ReactionThermoProps::dG0 , "The standard molar Gibbs energy change of the reaction (in J/mol)")
+        .def_readwrite("dH0" , &ReactionThermoProps::dH0 , "The standard molar enthalpy change of the reaction (in J/mol)")
+        .def_readwrite("dCp0", &ReactionThermoProps::dCp0, "The standard molar isobaric heat capacity change of the reaction (in J/(mol·K))")
         ;
 
     py::class_<ReactionThermoArgs>(m, "ReactionThermoArgs")

--- a/Reaktoro/Core/Species.py
+++ b/Reaktoro/Core/Species.py
@@ -101,6 +101,7 @@ def testSpecies():
         props = ReactionThermoProps()
         props.dG0 = T + P
         props.dH0 = T - P
+        props.dCp0 = T * P
         return props
 
     species = species.withFormationReaction(
@@ -112,3 +113,4 @@ def testSpecies():
 
     assert species.props(T, P).G0[0] == species.reaction().createStandardThermoModel()(T, P).G0[0]
     assert species.props(T, P).H0[0] == species.reaction().createStandardThermoModel()(T, P).H0[0]
+    assert species.props(T, P).Cp0[0] == species.reaction().createStandardThermoModel()(T, P).Cp0[0]

--- a/Reaktoro/Core/Species.test.cxx
+++ b/Reaktoro/Core/Species.test.cxx
@@ -87,7 +87,8 @@ TEST_CASE("Testing Species class", "[Species]")
                 2.0*T*P, // H0
                 3.0*T*P, // V0
                 4.0*T*P, // Cp0
-                5.0*T*P, // Cv0
+                5.0*T*P, // VT0
+                6.0*T*P, // VP0
             };
         });
 
@@ -95,6 +96,8 @@ TEST_CASE("Testing Species class", "[Species]")
         CHECK( species.standardThermoProps(T, P).H0  == Approx(2.0*T*P) );
         CHECK( species.standardThermoProps(T, P).V0  == Approx(3.0*T*P) );
         CHECK( species.standardThermoProps(T, P).Cp0 == Approx(4.0*T*P) );
+        CHECK( species.standardThermoProps(T, P).VT0 == Approx(5.0*T*P) );
+        CHECK( species.standardThermoProps(T, P).VP0 == Approx(6.0*T*P) );
 
         const auto R1 = Species().withName("R1").withStandardGibbsEnergy(0.0);
         const auto R2 = Species().withName("R2").withStandardGibbsEnergy(0.0);
@@ -108,12 +111,14 @@ TEST_CASE("Testing Species class", "[Species]")
                         const auto& [T, P, dV0] = args;
                         props.dG0 = T + P;
                         props.dH0 = T - P;
+                        props.dCp0 = T * P;
                         return props;
                     })
             );
 
         CHECK( species.standardThermoProps(T, P).G0 == species.reaction().createStandardThermoModel()(T, P).G0 );
         CHECK( species.standardThermoProps(T, P).H0 == species.reaction().createStandardThermoModel()(T, P).H0 );
+        CHECK( species.standardThermoProps(T, P).Cp0 == species.reaction().createStandardThermoModel()(T, P).Cp0 );
     }
 
     SECTION("Testing automatic construction of chemical species with given chemical formula")

--- a/Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.test.cxx
+++ b/Reaktoro/Extensions/Phreeqc/PhreeqcDatabase.test.cxx
@@ -59,6 +59,9 @@ auto lgK(const PhreeqcDatabase& db, real T, real P, const String& name) -> real;
 /// Calculate the actual enthalpy of formation reaction of a product species with given name.
 auto dH0(const PhreeqcDatabase& db, real T, real P, const String& name) -> real;
 
+/// Calculate the actual isobaric heat capacity of formation reaction of a product species with given name.
+auto dCp0(const PhreeqcDatabase& db, real T, real P, const String& name) -> real;
+
 /// Calculate the actual standard molar Gibbs energies of species with given name.
 auto G0(const PhreeqcDatabase& db, real T, real P, String name) -> real;
 
@@ -507,22 +510,22 @@ TEST_CASE("Testing pressure correction in standard thermodynamic properties calc
         CHECK(propsT0P0.G0  == Approx(-95213.7)    );
         CHECK(propsT0P0.H0  == Approx(-24010.3)    );
         CHECK(propsT0P0.V0  == Approx(3.44329e-05) );
-        CHECK(propsT0P0.Cp0 == Approx(0.0)         );
+        CHECK(propsT0P0.Cp0 == Approx(657.168)     );
 
         CHECK(propsT1P0.G0  == Approx(-113039)     );
         CHECK(propsT1P0.H0  == Approx(12124.6)     );
         CHECK(propsT1P0.V0  == Approx(3.77425e-05) );
-        CHECK(propsT1P0.Cp0 == Approx(0.0)         );
+        CHECK(propsT1P0.Cp0 == Approx(574.514)     );
 
         CHECK(propsT0P1.G0  == Approx(-95161)    );
         CHECK(propsT0P1.H0  == Approx(-23957.6)    );
         CHECK(propsT0P1.V0  == Approx(3.44286e-05) );
-        CHECK(propsT0P1.Cp0 == Approx(0.0)         );
+        CHECK(propsT0P1.Cp0 == Approx(657.168)     );
 
         CHECK(propsT1P1.G0  == Approx(-112978)     );
         CHECK(propsT1P1.H0  == Approx(12185.4)     );
         CHECK(propsT1P1.V0  == Approx(3.77222e-05) );
-        CHECK(propsT1P1.Cp0 == Approx(0.0)         );
+        CHECK(propsT1P1.Cp0 == Approx(574.514)     );
     }
 
     {
@@ -538,22 +541,22 @@ TEST_CASE("Testing pressure correction in standard thermodynamic properties calc
         CHECK(propsT0P0.G0  == Approx(-48402.9) );
         CHECK(propsT0P0.H0  == Approx(9608.99)  );
         CHECK(propsT0P0.V0  == Approx(3.69e-05) );
-        CHECK(propsT0P0.Cp0 == Approx(0.0)      );
+        CHECK(propsT0P0.Cp0 == Approx(295.096)     );
 
         CHECK(propsT1P0.G0  == Approx(-62078.3) );
         CHECK(propsT1P0.H0  == Approx(32690.1)  );
         CHECK(propsT1P0.V0  == Approx(3.69e-05) );
-        CHECK(propsT1P0.Cp0 == Approx(0.0)      );
+        CHECK(propsT1P0.Cp0 == Approx(474.274)     );
 
         CHECK(propsT0P1.G0  == Approx(-48347.9) );
         CHECK(propsT0P1.H0  == Approx(9664.07)  );
         CHECK(propsT0P1.V0  == Approx(3.69e-05) );
-        CHECK(propsT0P1.Cp0 == Approx(0.0)      );
+        CHECK(propsT0P1.Cp0 == Approx(295.096)     );
 
         CHECK(propsT1P1.G0  == Approx(-62017.7) );
         CHECK(propsT1P1.H0  == Approx(32750.7)  );
         CHECK(propsT1P1.V0  == Approx(3.69e-05) );
-        CHECK(propsT1P1.Cp0 == Approx(0.0)      );
+        CHECK(propsT1P1.Cp0 == Approx(474.274)     );
     }
 }
 
@@ -561,7 +564,7 @@ TEST_CASE("Testing pressure correction in standard thermodynamic properties calc
 // AUXILIARY FUNCTIONS: DEFINITION
 //=================================================================================================
 
-auto evalReactionThermoProps(const Species& species, real T, real P)
+auto evalReactionThermoProps(const Species& species, real T, real P) -> ReactionThermoProps
 {
     const auto dV0 = 0.0;
     return species.reaction().reactionThermoModel()({T, P, dV0});
@@ -581,6 +584,13 @@ auto dH0(const PhreeqcDatabase& db, real T, real P, const String& name) -> real
     const auto species = db.species().get(name);
     const auto dH0 = evalReactionThermoProps(species, T, P).dH0;
     return dH0;
+}
+
+auto dCp0(const PhreeqcDatabase& db, real T, real P, const String& name) -> real
+{
+    const auto species = db.species().get(name);
+    const auto dCp0 = evalReactionThermoProps(species, T, P).dCp0;
+    return dCp0;
 }
 
 auto G0(const PhreeqcDatabase& db, real T, real P, String name) -> real

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.cpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.cpp
@@ -38,9 +38,16 @@ namespace {
 /// Return the standard thermodynamic property function of a species with given name.
 auto createStandardThermoModel(const ThermoFunEngine& engine, const String& species) -> StandardThermoModel
 {
+    const auto& substances = engine.database().mapSubstances();
+    const auto it = substances.find(species);
+
+    errorif(it == substances.end(), "Expecting a species name that exists in the ThermoFun database, but got `", species, "` instead.");
+
+    const auto substance = it->second;
+
     return [=](real T, real P) -> StandardThermoProps
     {
-        return engine.props(T, P, species);
+        return engine.props(T, P, substance);
     };
 }
 

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.py
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.py
@@ -87,7 +87,7 @@ def testThermoFunDatabase():
     props = species.standardThermoProps(T, P)
     assert props.G0[0]  == pytest.approx(-3.943510e+05)
     assert props.H0[0]  == pytest.approx(-3.935472e+05)
-    assert props.V0[0]  == pytest.approx( 2.466434e-02)
+    assert props.V0[0]  == pytest.approx( 0.0000000000)
     assert props.Cp0[0] == pytest.approx( 3.710812e+01)
 
     #-------------------------------------------------------------------

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.test.cxx
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunDatabase.test.cxx
@@ -118,7 +118,7 @@ TEST_CASE("Testing ThermoFunDatabase", "[ThermoFunDatabase]")
     props = species.standardThermoProps(T, P);
     CHECK( props.G0  == Approx(-3.943510e+05) );
     CHECK( props.H0  == Approx(-3.935472e+05) );
-    CHECK( props.V0  == Approx( 2.466434e-02) );
+    CHECK( props.V0  == Approx(0.00000000000) );
     CHECK( props.VT0 == Approx(0.00000000000) );
     CHECK( props.VP0 == Approx(0.00000000000) );
     CHECK( props.Cp0 == Approx( 3.710812e+01) );

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.cpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.cpp
@@ -33,6 +33,11 @@ auto convertProps(const ThermoFun::ThermoPropertiesSubstance& other, const Therm
     converted.H0  = other.enthalpy.val;
     converted.V0  = other.volume.val * 1.0e-05; // from J/bar to m3/mol
     converted.Cp0 = other.heat_capacity_cp.val;
+
+    // Reaktoro expects zero standard molar volumes for gases.
+    if(substance.aggregateState() == ThermoFun::AggregateState::GAS)
+        converted.V0 = 0.0;
+
     return converted;
 }
 
@@ -76,7 +81,6 @@ struct ThermoFunEngine::Impl
         return convertProps(props, substance);
     }
 };
-
 
 ThermoFunEngine::ThermoFunEngine(const ThermoFun::Database& database)
 : pimpl(new Impl(database))

--- a/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.hpp
+++ b/Reaktoro/Extensions/ThermoFun/ThermoFunEngine.hpp
@@ -22,7 +22,7 @@
 #include <Reaktoro/Core/StandardThermoProps.hpp>
 
 // Forward declaration of ThermoFun classes
-namespace ThermoFun { class Database; }
+namespace ThermoFun { class Database; class Substance; }
 
 namespace Reaktoro {
 
@@ -39,6 +39,9 @@ public:
 
     /// Return the standard thermodynamic properties of a chemical species with given name.
     auto props(const real& T, const real& P, const String& species) const -> StandardThermoProps;
+
+    /// Return the standard thermodynamic properties of a chemical species with given ThermoFun::Substance object.
+    auto props(const real& T, const real& P, const ThermoFun::Substance& substance) const -> StandardThermoProps;
 
 private:
     struct Impl;

--- a/Reaktoro/Models/ReactionThermoModelConstLgK.cpp
+++ b/Reaktoro/Models/ReactionThermoModelConstLgK.cpp
@@ -58,6 +58,7 @@ auto ReactionThermoModelConstLgK(const ReactionThermoModelParamsConstLgK& params
 
         props.dG0 = -RT*lnKr + dE;
         props.dH0 = dE;
+        props.dCp0 = 0.0;
     };
 
     return ReactionThermoModel(evalfn, extractParams(params), createModelSerializer(params));

--- a/Reaktoro/Models/ReactionThermoModelConstLgK.hpp
+++ b/Reaktoro/Models/ReactionThermoModelConstLgK.hpp
@@ -38,20 +38,28 @@ struct ReactionThermoModelParamsConstLgK
 ///
 /// @eqc{\lg K(T)=\lg K_{\mathrm{r}},}
 ///
-/// where @eq{\lg K_{\mathrm{r}}} is a given equilibrium constant at a
-/// reference temperature and pressure.
+/// where @eq{\lg K_{\mathrm{r}}} is a given equilibrium constant at a reference temperature and pressure.
 ///
 /// The standard Gibbs energy of the reaction is computed using:
 ///
-/// @eqc{\Delta G^{\circ}(T,P)=-RT\ln K_{\mathrm{r}}+\Delta V^{\circ}(P-P_{\mathrm{r}})}
+/// @eqc{\Delta G^{\circ}(T,P)=-RT\ln K_{\mathrm{r}}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// while the standard enthalpy of the reaction is:
+/// the standard enthalpy of the reaction using:
 ///
 /// @eqc{\Delta H^{\circ}(T,P)=\Delta V^{\circ}(P-P_{\mathrm{r}}).}
 ///
+/// and the standard isobaric heat capacity of reaction using:
+///
+/// @eqc{\Delta C_{P}^{\circ}(T, P) = \Delta V^{\circ}_T(P-P_{\mathrm{r}}),}
+///
+/// where we have considered the following thermodynamic relations:
+///
+/// @eqc{\begin{align*} \Delta G^{\circ} & \equiv-RT\ln K,\vphantom{\left(-\frac{\Delta G^{\circ}}{T}\right)}\\ \Delta H^{\circ} & \equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)_{P}=RT^{2}\frac{\partial\ln K}{\partial T},\\ \Delta C_{P}^{\circ} & \equiv\left(\dfrac{\partial\Delta H^{\circ}}{\partial T}\right)_{P}. \end{align*}}
+///
 /// Note that a pressure correction is introduced above, where @eq{\Delta V^{\circ}}
 /// is the change of standard molar volume of the reaction at @eq{T} and @eq{P},
-/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure.
+/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure. @eq{\Delta V^{\circ}_T}
+/// is the temperature derivative of @eq{\Delta V^{\circ}} at constant pressure.
 auto ReactionThermoModelConstLgK(const ReactionThermoModelParamsConstLgK& params) -> ReactionThermoModel;
 
 } // namespace Reaktoro

--- a/Reaktoro/Models/ReactionThermoModelConstLgK.test.cxx
+++ b/Reaktoro/Models/ReactionThermoModelConstLgK.test.cxx
@@ -51,7 +51,7 @@ TEST_CASE("Testing ReactionThermoModelConstLgK class", "[ReactionThermoModelCons
 
     CHECK( rprops.dG0 == Approx(dG0x) );
     CHECK( rprops.dH0 == Approx(dH0x) );
-    CHECK( rprops.dCp00 == 0.0 );
+    CHECK( rprops.dCp0 == 0.0 );
 
     //======================================================================
     // Test method Model::params()

--- a/Reaktoro/Models/ReactionThermoModelConstLgK.test.cxx
+++ b/Reaktoro/Models/ReactionThermoModelConstLgK.test.cxx
@@ -51,6 +51,7 @@ TEST_CASE("Testing ReactionThermoModelConstLgK class", "[ReactionThermoModelCons
 
     CHECK( rprops.dG0 == Approx(dG0x) );
     CHECK( rprops.dH0 == Approx(dH0x) );
+    CHECK( rprops.dCp00 == 0.0 );
 
     //======================================================================
     // Test method Model::params()

--- a/Reaktoro/Models/ReactionThermoModelGemsLgK.cpp
+++ b/Reaktoro/Models/ReactionThermoModelGemsLgK.cpp
@@ -51,14 +51,18 @@ auto ReactionThermoModelGemsLgK(const ReactionThermoModelParamsGemsLgK& params) 
         // Unpack the model parameters
         const auto& [A0, A1, A2, A3, A4, A5, A6, Pr] = params;
 
+        const auto dVT0 = 0.0; // TODO: Consider dVT0 in ReactionThermoArgs
+
         const auto R = universalGasConstant;
         const auto T2 = T*T;
         const auto T3 = T*T2;
         const auto T05 = sqrt(T);
-        const auto dE = dV0 * (P - Pr); // delta energy (in J/mol)
+        const auto dE = dV0 * (P - Pr);  // delta energy (in J/mol)
+        const auto dET = dVT0 * (P - Pr);
 
-        props.dG0 = -R*T * (A0 + A1*T + A2/T + A3*log(T) + A4/T2 + A5*T2 + A6/T05)*ln10 + dE;
-        props.dH0 = R * (A1*T2 - A2 + A3*T - 2*A4/T + 2*A5*T3 - 0.5*A6*T05)*ln10 + dE;
+        props.dG0  = -R*T * (A0 + A1*T + A2/T + A3*log(T) + A4/T2 + A5*T2 + A6/T05)*ln10 + dE;
+        props.dH0  = R * (A1*T2 - A2 + A3*T - 2*A4/T + 2*A5*T3 - 0.5*A6*T05)*ln10 + dE;
+        props.dCp0 = R * (2*A1*T + A3 + 2*A4/T2 + 6*A5*T2 - 0.25*A6/T05)*ln10 + dET;
     };
 
     return ReactionThermoModel(evalfn, extractParams(params), createModelSerializer(params));

--- a/Reaktoro/Models/ReactionThermoModelGemsLgK.hpp
+++ b/Reaktoro/Models/ReactionThermoModelGemsLgK.hpp
@@ -54,26 +54,32 @@ struct ReactionThermoModelParamsGemsLgK
 ///
 /// In this model, the equilibrium constant of the reaction is computed at a given temperature with:
 ///
-/// @eqc{\log_{10}K=A_{0}+A_{1}T+A_{2}T^{-1}+A_{3}\ln T+A_{4}T^{-2}+A_{5}T^{2}+A_{6}T^{-0.5},}
+/// @eqc{\lg K(T)=A_{0}+A_{1}T+A_{2}T^{-1}+A_{3}\ln T+A_{4}T^{-2}+A_{5}T^{2}+A_{6}T^{-0.5},}
 ///
-/// where @eq{A_i} are given coefficients. From this model, we can calculate
-/// the standard Gibbs energy of reaction using:
+/// where @eq{A_i} are given coefficients.
 ///
-/// @eqc{\Delta G^{\circ}=-RT\left(A_{0}+A_{1}T+A_{2}T^{-1}+A_{3}\ln T+A_{4}T^{-2}+A_{5}T^{2}+A_{6}T^{-0.5}\right)\ln_{10}}
+/// The standard Gibbs energy of reaction is computed using:
 ///
-/// and the standard enthalpy of reaction using:
+/// @eqc{\Delta G^{\circ}(T,P)=-RT\left(A_{0}+A_{1}T+A_{2}T^{-1}+A_{3}\ln T+A_{4}T^{-2}+A_{5}T^{2}+A_{6}T^{-0.5}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta H^{\circ}=R\left(A_{1}T^{2}-A_{2}+A_{3}T-2A_{4}T^{-1}+2A_{5}T^{3}-0.5A_{6}T^{0.5}\right)\ln_{10},}
+/// the standard enthalpy of reaction using:
 ///
-/// considering that:
+/// @eqc{\Delta H^{\circ}(T,P)=R\left(A_{1}T^{2}-A_{2}+A_{3}T-2A_{4}T^{-1}+2A_{5}T^{3}-0.5A_{6}T^{0.5}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta G^{\circ}=-RT\ln K}
+/// and the standard isobaric heat capacity of reaction using:
 ///
-/// and
+/// @eqc{\Delta C_{P}^{\circ}(T,P)=R\left(2A_{1}T+A_{3}+2A_{4}T^{-2}+6A_{5}T^{2}-0.25A_{6}T^{-0.5}\right)\ln_{10}+\Delta V^{\circ}_T(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta H^{\circ}\equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)=RT^{2}\frac{\partial\ln K}{\partial T}.}
+/// where we have considered the following thermodynamic relations:
 ///
-/// Reference:
+/// @eqc{\begin{align*} \Delta G^{\circ} & \equiv-RT\ln K,\vphantom{\left(-\frac{\Delta G^{\circ}}{T}\right)}\\ \Delta H^{\circ} & \equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)_{P}=RT^{2}\frac{\partial\ln K}{\partial T},\\ \Delta C_{P}^{\circ} & \equiv\left(\dfrac{\partial\Delta H^{\circ}}{\partial T}\right)_{P}. \end{align*}}
+///
+/// Note that a pressure correction is introduced above, where @eq{\Delta V^{\circ}}
+/// is the change of standard molar volume of the reaction at @eq{T} and @eq{P},
+/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure. @eq{\Delta V^{\circ}_T}
+/// is the temperature derivative of @eq{\Delta V^{\circ}} at constant pressure.
+///
+/// **References:**
 /// - Kulik, D., Wagner T. (2010) Part 3. Temperature corrections of
 ///   standard molar (partial molal) thermodynamic properties of substances and
 ///   reactions using data in ReacDC records of GEM-Selektor.

--- a/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.cpp
+++ b/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.cpp
@@ -51,12 +51,16 @@ auto ReactionThermoModelPhreeqcLgK(const ReactionThermoModelParamsPhreeqcLgK& pa
         // Unpack the model parameters
         const auto& [A1, A2, A3, A4, A5, A6, Pr] = params;
 
+        const auto dVT0 = 0.0; // TODO: Consider dVT0 in ReactionThermoArgs
+
         const auto R = universalGasConstant;
         const auto T2 = T*T;
         const auto T3 = T*T2;
         const auto dE = dV0 * (P - Pr); // delta energy (in J/mol)
-        props.dG0 = -R*T * (A1 + A2*T + A3/T + A4*log10(T) + A5/T2 + A6*T2)*ln10 + dE;
-        props.dH0 = R * (A2*T2 - A3 + A4*T/ln10 - 2*A5/T + 2*A6*T3)*ln10 + dE;
+        const auto dET = dVT0 * (P - Pr);
+        props.dG0  = -R*T * (A1 + A2*T + A3/T + A4*log10(T) + A5/T2 + A6*T2)*ln10 + dE;
+        props.dH0  = R * (A2*T2 - A3 + A4*T/ln10 - 2*A5/T + 2*A6*T3)*ln10 + dE;
+        props.dCp0 = R * (2*A2*T + A4/ln10 + 2*A5/T2 + 6*A6*T2)*ln10 + dET;
     };
 
     return ReactionThermoModel(evalfn, extractParams(params), createModelSerializer(params));

--- a/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.hpp
+++ b/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.hpp
@@ -49,27 +49,32 @@ struct ReactionThermoModelParamsPhreeqcLgK
 
 /// Return a function that calculates thermodynamic properties of a reaction using PHREEQC's analytical expression.
 ///
-/// In this model, the equilibrium constant of the reaction
-/// is computed at a given temperature with:
+/// In this model, the equilibrium constant of the reaction is computed at a given temperature with:
 ///
-/// @eqc{\log_{10}K=A_{1}+A_{2}T+A_{3}T^{-1}+A_{4}\log_{10}T+A_{5}T^{-2}+A_{6}T^{2},}
+/// @eqc{\lg K(T)=A_{1}+A_{2}T+A_{3}T^{-1}+A_{4}\log_{10}T+A_{5}T^{-2}+A_{6}T^{2},}
 ///
-/// where @eq{A_i} are given coefficients. From this model, we can calculate
-/// the standard Gibbs energy of reaction using:
+/// where @eq{A_i} are given coefficients.
 ///
-/// @eqc{\Delta G^{\circ}=-RT\left(A_{1}+A_{2}T+A_{3}T^{-1}+A_{4}\log_{10}T+A_{5}T^{-2}+A_{6}T^{2}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}})}
+/// The standard Gibbs energy of reaction is computed using:
 ///
-/// and the standard enthalpy of reaction using:
+/// @eqc{\Delta G^{\circ}(T,P)=-RT\left(A_{1}+A_{2}T+A_{3}T^{-1}+A_{4}\log_{10}T+A_{5}T^{-2}+A_{6}T^{2}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta H^{\circ}=R\left(A_{2}T^{2}-A_{3}+\frac{A_{4}}{\ln10}T-2A_{5}T^{-1}+2A_{6}T^{3}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
+/// the standard enthalpy of reaction using:
 ///
-/// considering that:
+/// @eqc{\Delta H^{\circ}(T,P)=R\left(A_{2}T^{2}-A_{3}+\frac{A_{4}}{\ln10}T-2A_{5}T^{-1}+2A_{6}T^{3}\right)\ln_{10}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta G^{\circ}=-RT\ln K+\Delta V^{\circ}(P-P_{\mathrm{r}})}
+/// and the standard isobaric heat capacity of reaction using:
 ///
-/// and
+/// @eqc{\Delta C_{P}^{\circ}(T,P)=R\left(2A_{2}T+\frac{A_{4}}{\ln10}+2A_{5}T^{-2}+6A_{6}T^{2}\right)\ln_{10}+\Delta V_{T}^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta H^{\circ}\equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)=RT^{2}\frac{\partial\ln K}{\partial T}+\Delta V^{\circ}(P-P_{\mathrm{r}}).}
+/// where we have considered the following thermodynamic relations:
+///
+/// @eqc{\begin{align*} \Delta G^{\circ} & \equiv-RT\ln K,\vphantom{\left(-\frac{\Delta G^{\circ}}{T}\right)}\\ \Delta H^{\circ} & \equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)_{P}=RT^{2}\frac{\partial\ln K}{\partial T},\\ \Delta C_{P}^{\circ} & \equiv\left(\dfrac{\partial\Delta H^{\circ}}{\partial T}\right)_{P}. \end{align*}}
+///
+/// Note that a pressure correction is introduced above, where @eq{\Delta V^{\circ}}
+/// is the change of standard molar volume of the reaction at @eq{T} and @eq{P},
+/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure. @eq{\Delta V^{\circ}_T}
+/// is the temperature derivative of @eq{\Delta V^{\circ}} at constant pressure.
 ///
 /// Reference:
 /// - Parkhurst, D.L., Appelo, C.A.J. (2013). Description of input and examples

--- a/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.test.cxx
+++ b/Reaktoro/Models/ReactionThermoModelPhreeqcLgK.test.cxx
@@ -45,21 +45,25 @@ TEST_CASE("Testing ReactionThermoModelPhreeqcLgK class", "[ReactionThermoModelPh
 
     const auto R = universalGasConstant;
 
-    const auto lgK   = A1 + A2*T + A3/T + A4*log10(T) + A5/(T*T) + A6*T*T;
-    const auto lgK_T = A2 - A3/(T*T) + A4/(ln10*T) - 2*A5/(T*T*T) + 2*A6*T;
+    const auto lgK    = A1 + A2*T + A3/T + A4*log10(T) + A5/(T*T) + A6*T*T;
+    const auto lgK_T  = A2 - A3/(T*T) + A4/(ln10*T) - 2*A5/(T*T*T) + 2*A6*T;
+    const auto lgK_TT = 2*A3/(T*T*T) - A4/(ln10*T*T) + 6*A5/(T*T*T*T) + 2*A6;
 
-    const auto lnK   = ln10 * lgK;
-    const auto lnK_T = ln10 * lgK_T;
+    const auto lnK    = ln10 * lgK;
+    const auto lnK_T  = ln10 * lgK_T;
+    const auto lnK_TT = ln10 * lgK_TT;
 
     const auto dE = dV0 * (P - Pr);
 
-    const auto dG0x = -R*T*lnK + dE;     // expected dG0 at (T, P)
-    const auto dH0x =  R*T*T*lnK_T + dE; // expected dH0 at (T, P)
+    const auto dG0x  = -R*T*lnK + dE;             // expected dG0 at (T, P)
+    const auto dH0x  =  R*T*T*lnK_T + dE;         // expected dH0 at (T, P)
+    const auto dCp0x =  2*R*T*lnK_T + R*T*T*lnK_TT; // expected dCp0 at (T, P)
 
     ReactionThermoProps rprops = model({T, P, dV0});
 
-    CHECK( rprops.dG0 == Approx(dG0x) );
-    CHECK( rprops.dH0 == Approx(dH0x) );
+    CHECK( rprops.dG0  == Approx(dG0x)  );
+    CHECK( rprops.dH0  == Approx(dH0x)  );
+    CHECK( rprops.dCp0 == Approx(dCp0x) );
 
     //======================================================================
     // Test method Model::params()

--- a/Reaktoro/Models/ReactionThermoModelPressureCorrection.cpp
+++ b/Reaktoro/Models/ReactionThermoModelPressureCorrection.cpp
@@ -32,6 +32,7 @@ auto ReactionThermoModelPressureCorrection(Param Pr) -> ReactionThermoModel
         const auto dE = (P - Pr) * dV0; // delta energy (in J/mol)
         props.dG0 += dE;
         props.dH0 += dE;
+        props.dCp0 += 0.0; // TODO: Consider adding (P - Pr) * ΔVT0 in the future, taking into account temperature derivative of dV0.
     };
 
     Vec<Param> params = { Pr };

--- a/Reaktoro/Models/ReactionThermoModelPressureCorrection.hpp
+++ b/Reaktoro/Models/ReactionThermoModelPressureCorrection.hpp
@@ -24,15 +24,15 @@ namespace Reaktoro {
 
 /// Return a function that calculates pressure correction for standard Gibbs energy and enthalpy a reaction.
 ///
-/// In this model, the standard Gibbs energy and enthalpy of reaction are computed using:
+/// In this model, the standard Gibbs energy, enthalpy, and isobatic heat capacity of reaction are computed using:
 ///
 /// @eqc{\Delta G^{\circ}=\Delta G_{\mathrm{base}}^{\circ}+\Delta V^{\circ}(P-P_{r})}
 /// @eqc{\Delta H^{\circ}=\Delta H_{\mathrm{base}}^{\circ}+\Delta V^{\circ}(P-P_{r})}
+/// @eqc{\Delta C_P^{\circ}=\Delta C_{P,\mathrm{base}}^{\circ}}
 ///
-/// where @eq{\Delta G_{\mathrm{base}}^{\circ}} and @eq{\Delta H_{\mathrm{base}}^{\circ}}
-/// denote standard properties computed using a given base thermodynamic model
-/// function of the reaction.
-///
+/// where @eq{\Delta G_{\mathrm{base}}^{\circ}}, @eq{\Delta H_{\mathrm{base}}^{\circ}},
+/// and @eq{\Delta C_{P,\mathrm{base}}^{\circ}} denote standard properties computed using
+/// a given base thermodynamic model function of the reaction.
 /// @param Pr The reference pressure for the pressure correction (in Pa).
 auto ReactionThermoModelPressureCorrection(Param Pr) -> ReactionThermoModel;
 

--- a/Reaktoro/Models/ReactionThermoModelPressureCorrection.test.cxx
+++ b/Reaktoro/Models/ReactionThermoModelPressureCorrection.test.cxx
@@ -37,6 +37,7 @@ TEST_CASE("Testing ReactionThermoModelPressureCorrection class", "[ReactionTherm
     const auto dG0x = (P - Pref) * dV0; // expected dG0 at (T, P)
     const auto dH0x = (P - Pref) * dV0; // expected dH0 at (T, P)
 
-    CHECK( rprops.dG0 == Approx(dG0x) );
-    CHECK( rprops.dH0 == Approx(dH0x) );
+    CHECK( rprops.dG0  == Approx(dG0x) );
+    CHECK( rprops.dH0  == Approx(dH0x) );
+    CHECK( rprops.dCp0 == 0.0 );
 }

--- a/Reaktoro/Models/ReactionThermoModelVantHoff.cpp
+++ b/Reaktoro/Models/ReactionThermoModelVantHoff.cpp
@@ -51,13 +51,17 @@ auto ReactionThermoModelVantHoff(const ReactionThermoModelParamsVantHoff& params
         // Unpack the model parameters
         const auto& [lgKr, dHr, Tr, Pr] = params;
 
+        const auto dVT0 = 0.0; // TODO: Consider dVT0 in ReactionThermoArgs
+
         const auto R = universalGasConstant;
         const auto RT = R*T;
         const auto lnKr = lgKr * ln10;
         const auto lnK = lnKr - dHr * (Tr - T)/(RT*Tr);
         const auto dE = dV0 * (P - Pr); // delta energy (in J/mol)
+        const auto dET = dVT0 * (P - Pr); // delta energy (in J/mol)
         props.dG0 = -RT * lnK + dE;
         props.dH0 = dHr + dE;
+        props.dCp0 = dET;
     };
 
     return ReactionThermoModel(evalfn, extractParams(params), createModelSerializer(params));

--- a/Reaktoro/Models/ReactionThermoModelVantHoff.hpp
+++ b/Reaktoro/Models/ReactionThermoModelVantHoff.hpp
@@ -40,24 +40,33 @@ struct ReactionThermoModelParamsVantHoff
 
 /// Return a function that calculates thermodynamic properties of a reaction using van't Hoff's model.
 ///
-/// In this model, the equilibrium constant of the reaction
-/// is computed at a given temperature with:
+/// In this model, the equilibrium constant of the reaction is computed at a given temperature with:
 ///
-/// @eqc{\ln K=\ln K_{\mathrm{r}}-\frac{\Delta H_{\mathrm{r}}^{\circ}}{R}\left(\frac{1}{T}-\frac{1}{T_{\mathrm{r}}}\right),}
+/// @eqc{\ln K(T)=\ln K_{\mathrm{r}}-\frac{\Delta H_{\mathrm{r}}^{\circ}}{R}\left(\frac{1}{T}-\frac{1}{T_{\mathrm{r}}}\right),}
 ///
 /// where @eq{\ln K_{\mathrm{r}}} and @eq{\Delta H_{\mathrm{r}}^{\circ}} are the equilibrium constant and
-/// enthalpy of reaction at reference temperature @eq{T_\mathrm{r}}. From this model, we can calculate
-/// the standard Gibbs energy of reaction using:
+/// enthalpy of reaction at reference temperature @eq{T_\mathrm{r}}.
 ///
-/// @eqc{\Delta G^{\circ}=-RT\ln K_{\mathrm{r}}+\Delta V^{\circ}(P-P_{\mathrm{r}})}
+/// The standard Gibbs energy of reaction is computed using:
 ///
-/// while the standard enthalpy of reaction is:
+/// @eqc{\Delta G^{\circ}(T, P)=-RT\ln K_{\mathrm{r}}+\Delta V^{\circ}(P-P_{\mathrm{r}}),}
 ///
-/// @eqc{\Delta H^{\circ}=\Delta H_{\mathrm{r}}^{\circ}+\Delta V^{\circ}(P-P_{\mathrm{r}}).}
+/// the standard enthalpy of the reaction using:
+///
+/// @eqc{\Delta H^{\circ}(T, P)=\Delta H_{\mathrm{r}}^{\circ}+\Delta V^{\circ}(P-P_{\mathrm{r}}).}
+///
+/// and the standard isobaric heat capacity of reaction using:
+///
+/// @eqc{\Delta C_{P}^{\circ}(T, P) = \Delta V^{\circ}_T(P-P_{\mathrm{r}}),}
+///
+/// where we have considered the following thermodynamic relations:
+///
+/// @eqc{\begin{align*} \Delta G^{\circ} & \equiv-RT\ln K,\vphantom{\left(-\frac{\Delta G^{\circ}}{T}\right)}\\ \Delta H^{\circ} & \equiv T^{2}\frac{\partial}{\partial T}\left(-\frac{\Delta G^{\circ}}{T}\right)_{P}=RT^{2}\frac{\partial\ln K}{\partial T},\\ \Delta C_{P}^{\circ} & \equiv\left(\dfrac{\partial\Delta H^{\circ}}{\partial T}\right)_{P}. \end{align*}}
 ///
 /// Note that a pressure correction is introduced above, where @eq{\Delta V^{\circ}}
 /// is the change of standard molar volume of the reaction at @eq{T} and @eq{P},
-/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure.
+/// with @eq{P_{\mathrm{r}}} denoting a given reference pressure. @eq{\Delta V^{\circ}_T}
+/// is the temperature derivative of @eq{\Delta V^{\circ}} at constant pressure.
 auto ReactionThermoModelVantHoff(const ReactionThermoModelParamsVantHoff& params) -> ReactionThermoModel;
 
 } // namespace Reaktoro

--- a/Reaktoro/Models/ReactionThermoModelVantHoff.test.cxx
+++ b/Reaktoro/Models/ReactionThermoModelVantHoff.test.cxx
@@ -53,8 +53,9 @@ TEST_CASE("Testing ReactionThermoModelVantHoff class", "[ReactionThermoModelVant
 
     ReactionThermoProps rprops = model({T, P, dV0});
 
-    CHECK( rprops.dG0 == Approx(dG0x) );
-    CHECK( rprops.dH0 == Approx(dH0x) );
+    CHECK( rprops.dG0  == Approx(dG0x) );
+    CHECK( rprops.dH0  == Approx(dH0x) );
+    CHECK( rprops.dCp0 == 0.0 );
 
     //======================================================================
     // Test method Model::params()


### PR DESCRIPTION
This PR introduces the computation of standard isobaric heat capacity in `ReactionThermoProps`. The following standard thermodynamic models for reactions were updated:

* `ReactionThermoModelConstLgK`
* `ReactionThermoModelGemsLgK`
* `ReactionThermoModelPhreeqcLgK`
* `ReactionThermoModelPressureCorrection`
* `ReactionThermoModelVantHoff`

With this PR, it will be possible to compute thermodynamic properties related to standard heat capacities when using thermodynamic databases formulated in terms of reactions, such as PHREEQC databases for example.

This PR was created after @dover22 reporting via Gitter the lack of heat capacity property when using PHREEQC databases.