### PR TITLE
Fixes for the bugs discovered during the testing of python package `reaktoro-v2.0.0rc18`

### DIFF
--- a/Reaktoro/Equilibrium/EquilibriumSolver.cpp
+++ b/Reaktoro/Equilibrium/EquilibriumSolver.cpp
@@ -87,6 +87,9 @@ struct EquilibriumSolver::Impl
     /// The solver for the optimization calculations.
     Optima::Solver optsolver;
 
+    // The equilibrium result
+    EquilibriumResult result;
+
     /// Construct a Impl instance with given EquilibriumConditions object.
     Impl(const EquilibriumSpecs& specs)
     : system(specs.system()), specs(specs), dims(specs), setup(specs)
@@ -230,7 +233,7 @@ struct EquilibriumSolver::Impl
     auto updateOptState(const ChemicalState& state0)
     {
         // Allocate memory if needed
-        if(optstate.dims.x != dims.Nx)
+        if( (optstate.dims.x != dims.Nx) || (!result.optima.succeeded))
             optstate = Optima::State(optdims);
 
         // Set species amounts in x = (n, q) to that from the chemical state
@@ -388,8 +391,6 @@ struct EquilibriumSolver::Impl
 
     auto solve(ChemicalState& state, const EquilibriumConditions& conditions, const EquilibriumRestrictions& restrictions, ArrayXdConstRef b0) -> EquilibriumResult
     {
-        EquilibriumResult result;
-
         updateOptProblem(state, conditions, restrictions, b0);
         updateOptState(state);
 

--- a/Reaktoro/Thermodynamics/Surface/IonExchangeProps.cpp
+++ b/Reaktoro/Thermodynamics/Surface/IonExchangeProps.cpp
@@ -339,7 +339,7 @@ auto operator<<(std::ostream& out, const IonExchangeProps& props) -> std::ostrea
         table.add_row({ ":: " + species[i].repr(), strsci(ns[i]), "mol" });
     table.add_row({ "Equivalents:" });
     for(auto i = 0; i < species.size(); ++i)
-        table.add_row({ ":: " + species[i].repr(), strfix(eq[i]), "eq" });
+        table.add_row({ ":: " + species[i].repr(), strsci(eq[i]), "eq" });
     table.add_row({ "Equivalent Fractions:" });
     for(auto i = 0; i < species.size(); ++i)
         table.add_row({ ":: " + species[i].repr(), strfix(beta[i]), "" });

--- a/Reaktoro/Utils/Material.cpp
+++ b/Reaktoro/Utils/Material.cpp
@@ -31,7 +31,6 @@ using namespace tabulate;
 #include <Reaktoro/Equilibrium/EquilibriumOptions.hpp>
 #include <Reaktoro/Equilibrium/EquilibriumRestrictions.hpp>
 #include <Reaktoro/Equilibrium/EquilibriumResult.hpp>
-#include <Reaktoro/Equilibrium/EquilibriumSolver.hpp>
 #include <Reaktoro/Equilibrium/EquilibriumUtils.hpp>
 
 namespace Reaktoro {

--- a/examples/cpp/ex-equilibrium-phreeqc-ion-exchange-simple.cpp
+++ b/examples/cpp/ex-equilibrium-phreeqc-ion-exchange-simple.cpp
@@ -85,7 +85,10 @@ int main()
     std::cout << "pH = " << aprops.pH() << std::endl;
     std::cout << "pE = " << aprops.pE() << std::endl;
 
-    IonExchangeProps exprops(solutionstate);
+    //IonExchangeProps exprops(solutionstate);
+    IonExchangeProps exprops(system);
+    exprops.update(solutionstate);
+
     std::cout << exprops << std::endl;
 
     return 0;

--- a/examples/python/ex-equilibrium-ion-exchange-simple.py
+++ b/examples/python/ex-equilibrium-ion-exchange-simple.py
@@ -66,5 +66,6 @@ print("I  = %f mol/kgw" % aqprops.ionicStrength()[0])
 print("pH = %f" % aqprops.pH()[0])
 print("pE = %f" % aqprops.pE()[0])
 
-exprops = IonExchangeProps(state)
+exprops = IonExchangeProps(system)
+exprops.update(state)
 print(exprops)


### PR DESCRIPTION
This PR implements several fixes for the bugs discovered during testing of python package `reaktorov2.0.0rc18`. They are meant to be included in the next conda release. 

Tasks:

- [x] Fix the output of equivalents when applying operator `<<` to the IonExchangeProps.
- [x] Reiniitialize `optstate` in `EquilibrateSolver` class, when the previous run of the `solver.solve()` didn't converge. As a result, avoid copying incorrect Lagrangian multiplies from the previous chemical state obtained by the diverged Gibbs energy minimization problem to the current one. 
- [x] Remove unused includes.