### PR TITLE
Using Indices instead of ArrayXl

### DIFF
--- a/Reaktoro/Common.py.cxx
+++ b/Reaktoro/Common.py.cxx
@@ -25,6 +25,7 @@ void exportParseUtils(py::module& m);
 void exportStringList(py::module& m);
 void exportStringUtils(py::module& m);
 void exportUnits(py::module& m);
+void exportTypes(py::module& m);
 void exportYAML(py::module& m);
 
 void exportCommon(py::module& m)
@@ -36,5 +37,6 @@ void exportCommon(py::module& m)
     exportStringList(m);
     exportStringUtils(m);
     exportUnits(m);
+    exportTypes(m);
     exportYAML(m);
 }

--- a/Reaktoro/Common/Types.py
+++ b/Reaktoro/Common/Types.py
@@ -1,0 +1,50 @@
+# Reaktoro is a unified framework for modeling chemically reactive systems.
+#
+# Copyright © 2014-2022 Allan Leal
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+
+from reaktoro import *
+import pytest
+
+
+def testTypes():
+
+    indices = Indices()
+
+    assert indices.size() == 0
+
+    indices.append(1)
+
+    assert indices.size() == 1
+    assert len(indices) == 1
+
+    indices.push_back(2)
+
+    assert indices.size() == 2
+    assert len(indices) == 2
+
+    assert indices.front() == 1
+    assert indices.back() == 2
+
+    indices.append(3)
+
+    assert indices[0] == 1
+    assert indices[1] == 2
+    assert indices[2] == 3
+
+    for i, val in enumerate(indices):
+        assert val == i + 1
+

--- a/Reaktoro/Common/Types.py.cxx
+++ b/Reaktoro/Common/Types.py.cxx
@@ -1,0 +1,61 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// pybind11 includes
+#include <Reaktoro/pybind11.hxx>
+
+// Reaktoro includes
+#include <Reaktoro/Common/Types.hpp>
+using namespace Reaktoro;
+
+void exportTypes(py::module& m)
+{
+    const auto __getitem__ = [](const Indices& self, std::size_t i) { return self[i]; };
+    const auto __setitem__ = [](Indices& self, std::size_t i, Index val) { self[i] = val; };
+
+    const auto push_back = [](Indices& self, const Index& i) { self.push_back(i); };
+
+    auto createIndices = [](py::list l)
+    {
+        Indices res(l.size());
+        for(auto i = 0; i < res.size(); ++i)
+            res[i] = l[i].cast<Index>();
+        return res;
+    };
+
+    py::class_<Indices>(m, "Indices")
+        .def(py::init<>())
+        .def(py::init(createIndices))
+        .def("empty", &Indices::empty)
+        .def("size", &Indices::size)
+        .def("pop_back", &Indices::pop_back)
+        .def("push_back", push_back)
+        .def("append", push_back)
+        .def("front", [](const Indices& self) { return self.front(); }, return_internal_ref)
+        .def("front", [](Indices& self) { return self.front(); }, return_internal_ref)
+        .def("back", [](const Indices& self) { return self.back(); }, return_internal_ref)
+        .def("back", [](Indices& self) { return self.back(); }, return_internal_ref)
+        .def("__len__", &Indices::size)
+        .def("__iter__", [](Indices& self) { return py::make_iterator(self.begin(), self.end()); }, py::keep_alive<0, 1>())
+        .def("__getitem__", __getitem__, return_internal_ref)
+        .def("__setitem__", __setitem__)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        ;
+
+    py::implicitly_convertible<py::list, Indices>();
+}

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -219,7 +219,7 @@ auto ChemicalProps::chargeInPhase(StringOrIndex phase) const -> real
     return Azp * np;
 }
 
-auto ChemicalProps::chargeAmongSpecies(ArrayXlConstRef indices) const -> real
+auto ChemicalProps::chargeAmongSpecies(const Indices& indices) const -> real
 {
     const auto Az = msystem.formulaMatrixCharge();
     const auto Azi = Az.row(0)(indices);
@@ -246,7 +246,7 @@ auto ChemicalProps::elementAmountInPhase(StringOrIndex element, StringOrIndex ph
     return Aep * np;
 }
 
-auto ChemicalProps::elementAmountAmongSpecies(StringOrIndex element, ArrayXlConstRef indices) const -> real
+auto ChemicalProps::elementAmountAmongSpecies(StringOrIndex element, const Indices& indices) const -> real
 {
     const auto ielement = detail::resolveElementIndex(msystem, element);
     const auto A = msystem.formulaMatrixElements();
@@ -272,7 +272,7 @@ auto ChemicalProps::elementMassInPhase(StringOrIndex element, StringOrIndex phas
     return amount * molarmass;
 }
 
-auto ChemicalProps::elementMassAmongSpecies(StringOrIndex element, ArrayXlConstRef indices) const -> real
+auto ChemicalProps::elementMassAmongSpecies(StringOrIndex element, const Indices& indices) const -> real
 {
     const auto ielement = detail::resolveElementIndex(msystem, element);
     const auto molarmass = msystem.element(ielement).molarMass();
@@ -297,7 +297,7 @@ auto ChemicalProps::elementAmountsInPhase(StringOrIndex phase) const -> ArrayXr
     return (Ap * np).array();
 }
 
-auto ChemicalProps::elementAmountsAmongSpecies(ArrayXlConstRef indices) const -> ArrayXr
+auto ChemicalProps::elementAmountsAmongSpecies(const Indices& indices) const -> ArrayXr
 {
     const auto A = msystem.formulaMatrixElements();
     const auto Ai = A(Eigen::all, indices);
@@ -322,7 +322,7 @@ auto ChemicalProps::componentAmountsInPhase(StringOrIndex phase) const -> ArrayX
     return (Ap * np).array();
 }
 
-auto ChemicalProps::componentAmountsAmongSpecies(ArrayXlConstRef indices) const -> ArrayXr
+auto ChemicalProps::componentAmountsAmongSpecies(const Indices& indices) const -> ArrayXr
 {
     const auto A = msystem.formulaMatrix();
     const auto Ai = A(Eigen::all, indices);

--- a/Reaktoro/Core/ChemicalProps.hpp
+++ b/Reaktoro/Core/ChemicalProps.hpp
@@ -112,7 +112,7 @@ public:
 
     /// Return the amount of electric charge among a group of species in the system (in mol).
     /// @param indices The indices of the species in the system.
-    auto chargeAmongSpecies(ArrayXlConstRef indices) const -> real;
+    auto chargeAmongSpecies(const Indices& indices) const -> real;
 
     /// Return the amount of an element in the system (in mol).
     /// @param element The symbol or index of the element in the system.
@@ -126,7 +126,7 @@ public:
     /// Return the amount of an element among a group of species in the system (in mol).
     /// @param element The symbol or index of the element in the system.
     /// @param indices The indices of the species in the system.
-    auto elementAmountAmongSpecies(StringOrIndex element, ArrayXlConstRef indices) const -> real;
+    auto elementAmountAmongSpecies(StringOrIndex element, const Indices& indices) const -> real;
 
     /// Return the mass of an element in the system (in kg).
     /// @param element The symbol or index of the element in the system.
@@ -140,7 +140,7 @@ public:
     /// Return the mass of an element among a group of species in the system (in kg).
     /// @param element The symbol or index of the element in the system.
     /// @param indices The indices of the species in the system.
-    auto elementMassAmongSpecies(StringOrIndex element, ArrayXlConstRef indices) const -> real;
+    auto elementMassAmongSpecies(StringOrIndex element, const Indices& indices) const -> real;
 
     /// Return the amounts of the elements in the system (in mol).
     auto elementAmounts() const -> ArrayXr;
@@ -151,7 +151,7 @@ public:
 
     /// Return the amounts of the elements among a group of species in the system (in mol).
     /// @param indices The indices of the species in the system.
-    auto elementAmountsAmongSpecies(ArrayXlConstRef indices) const -> ArrayXr;
+    auto elementAmountsAmongSpecies(const Indices& indices) const -> ArrayXr;
 
     /// Return the amounts of the conservative components (elements and charge) in the system (in mol).
     auto componentAmounts() const -> ArrayXr;
@@ -162,7 +162,7 @@ public:
 
     /// Return the amounts of the conservative components (elements and charge) among a group of species in the system (in mol).
     /// @param indices The indices of the species in the system.
-    auto componentAmountsAmongSpecies(ArrayXlConstRef indices) const -> ArrayXr;
+    auto componentAmountsAmongSpecies(const Indices& indices) const -> ArrayXr;
 
     /// Return the amount of a species in the system (in mol).
     /// @param species The name or index of the species in the system.

--- a/Reaktoro/Core/ChemicalProps.test.cxx
+++ b/Reaktoro/Core/ChemicalProps.test.cxx
@@ -528,24 +528,24 @@ TEST_CASE("Testing ChemicalProps class", "[ChemicalProps]")
         CHECK( props.chargeInPhase(1) == Approx(z1) );
         CHECK( props.chargeInPhase("SomeGas") == Approx(z0) );
         CHECK( props.chargeInPhase("SomeSolid") == Approx(z1) );
-        CHECK( props.chargeAmongSpecies(ArrayXl{{0, 1}}) == Approx(z0) );
-        CHECK( props.chargeAmongSpecies(ArrayXl{{2}}) == Approx(z1) );
+        CHECK( props.chargeAmongSpecies({0, 1}) == Approx(z0) );
+        CHECK( props.chargeAmongSpecies({2}) == Approx(z1) );
 
         CHECK( props.elementAmounts().matrix().isApprox(be) );
         CHECK( props.elementAmountsInPhase(0).matrix().isApprox(be0) );
         CHECK( props.elementAmountsInPhase(1).matrix().isApprox(be1) );
         CHECK( props.elementAmountsInPhase("SomeGas").matrix().isApprox(be0) );
         CHECK( props.elementAmountsInPhase("SomeSolid").matrix().isApprox(be1) );
-        CHECK( props.elementAmountsAmongSpecies(ArrayXl{{0, 1}}).matrix().isApprox(be0) );
-        CHECK( props.elementAmountsAmongSpecies(ArrayXl{{2}}).matrix().isApprox(be1) );
+        CHECK( props.elementAmountsAmongSpecies({0, 1}).matrix().isApprox(be0) );
+        CHECK( props.elementAmountsAmongSpecies({2}).matrix().isApprox(be1) );
 
         CHECK( props.componentAmounts().matrix().isApprox(b) );
         CHECK( props.componentAmountsInPhase(0).matrix().isApprox(b0) );
         CHECK( props.componentAmountsInPhase(1).matrix().isApprox(b1) );
         CHECK( props.componentAmountsInPhase("SomeGas").matrix().isApprox(b0) );
         CHECK( props.componentAmountsInPhase("SomeSolid").matrix().isApprox(b1) );
-        CHECK( props.componentAmountsAmongSpecies(ArrayXl{{0, 1}}).matrix().isApprox(b0) );
-        CHECK( props.componentAmountsAmongSpecies(ArrayXl{{2}}).matrix().isApprox(b1) );
+        CHECK( props.componentAmountsAmongSpecies({0, 1}).matrix().isApprox(b0) );
+        CHECK( props.componentAmountsAmongSpecies({2}).matrix().isApprox(b1) );
 
         CHECK( props.elementAmount("H")  == Approx(b[idxElement("H")]) );
         CHECK( props.elementAmount("O")  == Approx(b[idxElement("O")]) );

--- a/Reaktoro/Core/ChemicalState.cpp
+++ b/Reaktoro/Core/ChemicalState.cpp
@@ -214,7 +214,7 @@ struct ChemicalState::Impl
         n *= scalar;
     }
 
-    auto scaleSpeciesAmounts(double scalar, ArrayXlConstRef indices) -> void
+    auto scaleSpeciesAmounts(double scalar, const Indices& indices) -> void
     {
         errorif(scalar < 0.0, "Expecting a non-negative scaling factor, but got ", scalar);
         n(indices) *= scalar;
@@ -563,7 +563,7 @@ auto ChemicalState::scaleSpeciesAmounts(real scalar) -> void
     pimpl->scaleSpeciesAmounts(scalar);
 }
 
-auto ChemicalState::scaleSpeciesAmounts(real scalar, ArrayXlConstRef indices) -> void
+auto ChemicalState::scaleSpeciesAmounts(real scalar, const Indices& indices) -> void
 {
     pimpl->scaleSpeciesAmounts(scalar, indices);
 }

--- a/Reaktoro/Core/ChemicalState.hpp
+++ b/Reaktoro/Core/ChemicalState.hpp
@@ -191,7 +191,7 @@ public:
     /// Scale the amounts of the species with given indices.
     /// @param scalar The scale factor
     /// @param indices The indices of the species
-    auto scaleSpeciesAmounts(real scalar, ArrayXlConstRef indices) -> void;
+    auto scaleSpeciesAmounts(real scalar, const Indices& indices) -> void;
 
     /// Scale the amounts of the species in a phase by a given factor.
     /// @param phase The name or index of the phase in the system.

--- a/Reaktoro/Core/ChemicalState.py.cxx
+++ b/Reaktoro/Core/ChemicalState.py.cxx
@@ -65,7 +65,7 @@ void exportChemicalState(py::module& m)
         .def("charge", &ChemicalState::charge)
 
         .def("scaleSpeciesAmounts", py::overload_cast<real>(&ChemicalState::scaleSpeciesAmounts))
-        .def("scaleSpeciesAmounts", py::overload_cast<real, ArrayXlConstRef>(&ChemicalState::scaleSpeciesAmounts))
+        .def("scaleSpeciesAmounts", py::overload_cast<real, const Indices&>(&ChemicalState::scaleSpeciesAmounts))
         .def("scaleSpeciesAmountsInPhase", &ChemicalState::scaleSpeciesAmountsInPhase)
 
         .def("scaleVolume", &ChemicalState::scaleVolume)

--- a/Reaktoro/Core/ReactionProps.py.cxx
+++ b/Reaktoro/Core/ReactionProps.py.cxx
@@ -16,8 +16,7 @@
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 // pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <Reaktoro/pybind11.hxx>
 
 // Reaktoro includes
 #include <Reaktoro/Core/ReactionProps.hpp>

--- a/Reaktoro/Core/SpeciesThermoProps.py.cxx
+++ b/Reaktoro/Core/SpeciesThermoProps.py.cxx
@@ -16,8 +16,7 @@
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 // pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <Reaktoro/pybind11.hxx>
 
 // Reaktoro includes
 #include <Reaktoro/Core/SpeciesThermoProps.hpp>

--- a/Reaktoro/Extensions/Nasa.py.cxx
+++ b/Reaktoro/Extensions/Nasa.py.cxx
@@ -16,8 +16,7 @@
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 // pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <Reaktoro/pybind11.hxx>
 
 void exportNasaDatabase(py::module& m);
 

--- a/Reaktoro/Extensions/Nasa/NasaDatabase.py.cxx
+++ b/Reaktoro/Extensions/Nasa/NasaDatabase.py.cxx
@@ -16,8 +16,7 @@
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 // pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <Reaktoro/pybind11.hxx>
 
 // Reaktoro includes
 #include <Reaktoro/Extensions/Nasa/NasaDatabase.hpp>

--- a/Reaktoro/pybind11.hxx
+++ b/Reaktoro/pybind11.hxx
@@ -29,11 +29,12 @@ namespace py = pybind11;
 // Reaktoro includes
 #include <Reaktoro/Common/Matrix.hpp>
 
+const auto return_internal_ref = py::return_value_policy::reference_internal;
+
 PYBIND11_MAKE_OPAQUE(Reaktoro::ArrayXr);
 PYBIND11_MAKE_OPAQUE(Reaktoro::ArrayXrRef);
 PYBIND11_MAKE_OPAQUE(Reaktoro::ArrayXrConstRef);
 PYBIND11_MAKE_OPAQUE(Reaktoro::VectorXr);
 PYBIND11_MAKE_OPAQUE(Reaktoro::VectorXrRef);
 PYBIND11_MAKE_OPAQUE(Reaktoro::VectorXrConstRef);
-
-const auto return_internal_ref = py::return_value_policy::reference_internal;
+PYBIND11_MAKE_OPAQUE(Reaktoro::Indices);

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -9,7 +9,7 @@ dependencies:
   - autodiff=0.6.5
   - catch2
   - ccache  # [unix]
-  - clangxx_osx-64=11.1.0  # [osx]
+  - clangxx_osx-64  # [osx]
   - clcache  # [win]
   - cmake
   - cpp-tabulate
@@ -18,7 +18,7 @@ dependencies:
   - fire
   - git
   - graphviz  # [linux]
-  - gxx_linux-64=9.4.0  # [linux]
+  - gxx_linux-64  # [linux]
   - make  # [unix]
   - ninja
   - nlohmann_json

--- a/resources/template/Class.py.cxx
+++ b/resources/template/Class.py.cxx
@@ -16,8 +16,7 @@
 // along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 // pybind11 includes
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <Reaktoro/pybind11.hxx>
 
 // Reaktoro includes
 #include "Class.hpp" // Replate with #include <Reaktoro/Module/Class.hpp>


### PR DESCRIPTION
This PR replaces usage of ArrayXl as function arguments with Indices (aka `std::vector<std::size_t>`).