### PR TITLE
Fixes dependencies tabulate pugixml

### DIFF
--- a/Reaktoro/CMakeLists.txt
+++ b/Reaktoro/CMakeLists.txt
@@ -29,7 +29,6 @@ target_include_directories(Reaktoro
 
 # Link Reaktoro library against external dependencies
 target_link_libraries(Reaktoro
-    PRIVATE pugixml
     PRIVATE Reaktoro::Databases
     PUBLIC Eigen3::Eigen
     PUBLIC autodiff::autodiff

--- a/Reaktoro/CMakeLists.txt
+++ b/Reaktoro/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(Reaktoro
     PUBLIC Optima::Optima
     PUBLIC nlohmann_json::nlohmann_json
     PUBLIC phreeqc4rkt::phreeqc4rkt
+    PUBLIC tabulate::tabulate
     PUBLIC ThermoFun::ThermoFun
     PUBLIC yaml-cpp
 )

--- a/Reaktoro/Common/YAML.cpp
+++ b/Reaktoro/Common/YAML.cpp
@@ -25,7 +25,7 @@ namespace Reaktoro {
 namespace {
 
 /// An auxiliary type to change locale and ensure its return to original.
-/// This is needed to avoid certain issues with pugixml related to how decimal numbers are represented in different languages.
+/// This is needed to avoid certain issues related to how decimal numbers are represented in different languages.
 struct ChangeLocale
 {
     const std::string old_locale;

--- a/Reaktoro/Models/ReactionThermoModelYAML.cpp
+++ b/Reaktoro/Models/ReactionThermoModelYAML.cpp
@@ -45,6 +45,8 @@ auto ReactionThermoModelYAML(const yaml& node) -> ReactionThermoModel
         return ReactionThermoModelVantHoff(params);
     errorif(true, "Cannot create a ReactionThermoModel with "
         "unsupported model name `", model, "` in yaml node:\n", node.repr());
+
+    return {};
 }
 
 } // namespace Reaktoro

--- a/Reaktoro/Models/StandardThermoModelYAML.cpp
+++ b/Reaktoro/Models/StandardThermoModelYAML.cpp
@@ -57,6 +57,8 @@ auto StandardThermoModelYAML(const yaml& node) -> StandardThermoModel
         return StandardThermoModelNasa(params);
     errorif(true, "Cannot create a StandardThermoModel with "
         "unsupported model name `", model, "` in yaml node:\n", node.repr());
+
+    return {};
 }
 
 } // namespace Reaktoro

--- a/cmake/ReaktoroFindDeps.cmake
+++ b/cmake/ReaktoroFindDeps.cmake
@@ -9,6 +9,7 @@ set(REAKTORO_USE_nlohmann_json "" CACHE PATH "Specify this option in case a spec
 set(REAKTORO_USE_Optima        "" CACHE PATH "Specify this option in case a specific Optima library should be used.")
 set(REAKTORO_USE_phreeqc4rkt   "" CACHE PATH "Specify this option in case a specific Phreeqc library should be used.")
 set(REAKTORO_USE_pybind11      "" CACHE PATH "Specify this option in case a specific pybind11 library should be used.")
+set(REAKTORO_USE_tabulate      "" CACHE PATH "Specify this option in case a specific tabulate library should be used.")
 set(REAKTORO_USE_ThermoFun     "" CACHE PATH "Specify this option in case a specific ThermoFun library should be used.")
 set(REAKTORO_USE_yaml-cpp      "" CACHE PATH "Specify this option in case a specific yaml-cpp library should be used.")
 
@@ -32,6 +33,7 @@ ReaktoroFindPackage(Eigen3 3.3.90)
 ReaktoroFindPackage(nlohmann_json 3.6.1)
 ReaktoroFindPackage(Optima 0.2.3)
 ReaktoroFindPackage(phreeqc4rkt 3.6.2.1)
+ReaktoroFindPackage(tabulate 1.4.0)
 ReaktoroFindPackage(ThermoFun 0.3.7)
 ReaktoroFindPackage(yaml-cpp 0.6.3)
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -29,7 +29,6 @@ dependencies:
   - pandas
   - phreeqc4rkt
   - pip
-  - pugixml
   - pybind11
   - pybind11-abi
   - pybind11-stubgen


### PR DESCRIPTION
This PR fixes the issue raised in #265, related to dependencies `tabulate` and `pugixml`. 

The issue related to `phreeqc4rkt` has been resolved [in this commit](https://github.com/reaktoro/phreeqc4rkt/commit/19e524e3a096d13ad15d3421a6b19ca3f7724d7a).

Fix #265