### PR TITLE
Introduce checks to prevent definition of phases and chemical systems without species

### DIFF
--- a/Reaktoro/Core/ChemicalSystem.cpp
+++ b/Reaktoro/Core/ChemicalSystem.cpp
@@ -75,6 +75,9 @@ struct ChemicalSystem::Impl
     Impl(const Database& database, const Vec<Phase>& phaselist)
     : database(database), phases(phaselist)
     {
+        errorif(database.species().empty(), "Expecting at least one species in the Database object provided when creating a ChemicalSystem object.");
+        errorif(phases.empty(), "Expecting at least one phase when creating a ChemicalSystem object, but none was provided.");
+
         species = phases.species();
         elements = species.elements();
         formula_matrix = detail::assembleFormulaMatrix(species, elements);

--- a/Reaktoro/Core/Phases.cpp
+++ b/Reaktoro/Core/Phases.cpp
@@ -22,6 +22,18 @@
 
 namespace Reaktoro {
 
+auto speciate(const StringList& symbols) -> Speciate
+{
+    errorif(symbols.empty(), "Expecting a non-empty list of element names in method `speciate`.");
+    return Speciate{symbols};
+}
+
+auto exclude(const StringList& tags) -> Exclude
+{
+    errorif(tags.empty(), "Expecting a non-empty list of tags in method `exclude`.");
+    return Exclude{tags};
+}
+
 GenericPhase::GenericPhase()
 {}
 

--- a/Reaktoro/Core/Phases.cpp
+++ b/Reaktoro/Core/Phases.cpp
@@ -165,6 +165,8 @@ auto GenericPhase::convert(const Database& db, const Strings& elements) const ->
     if(excludetags.size())
         species = species.withoutTags(excludetags);
 
+    errorif(species.empty(), "Expecting at least one species when defining a phase, but none was provided. Make sure you have listed the species names yourself or used the `speciate` method appropriately.")
+
     Phase phase;
     phase = phase.withName(phasename);
     phase = phase.withStateOfMatter(stateofmatter);
@@ -302,6 +304,8 @@ auto GenericPhasesGenerator::convert(const Database& db, const Strings& elements
     // Filter out species with provided tags in the exclude function
     if(excludetags.size())
         species = species.withoutTags(excludetags);
+
+    errorif(species.empty(), "Expecting at least one species when defining a list of single-species phases, but none was provided. Make sure you have listed the species names yourself or used the `speciate` method appropriately.")
 
     Vec<GenericPhase> phases;
     phases.reserve(species.size());

--- a/Reaktoro/Core/Phases.hpp
+++ b/Reaktoro/Core/Phases.hpp
@@ -42,7 +42,7 @@ struct Speciate
 };
 
 /// The auxiliary function used to specify phase species to be determined from element symbols.
-inline auto speciate(const StringList& symbols) { return Speciate{symbols}; }
+auto speciate(const StringList& symbols) -> Speciate;
 
 /// The auxiliary type used to specify species that should be filtered out when contructing a phase.
 struct Exclude
@@ -55,7 +55,7 @@ struct Exclude
 };
 
 /// The auxiliary function used to specify species that should be filtered out when contructing a phase.
-inline auto exclude(const StringList& tags) { return Exclude{tags}; }
+auto exclude(const StringList& tags) -> Exclude;
 
 /// The base type for all other classes defining more specific phases.
 /// @ingroup Core

--- a/Reaktoro/Core/Phases.test.cxx
+++ b/Reaktoro/Core/Phases.test.cxx
@@ -208,6 +208,13 @@ TEST_CASE("Testing Phases", "[Phases]")
         CHECK( phase.idealActivityModel() );
     }
 
+    SECTION("Testing bad use of GenericPhase")
+    {
+        GenericPhase genericphase;
+
+        CHECK_THROWS( genericphase.convert(db, {}) ); // no species nor elements provided!
+    }
+
     //=================================================================================================================
     //-----------------------------------------------------------------------------------------------------------------
     // TESTING CLASS: GenericPhasesGenerator
@@ -353,6 +360,13 @@ TEST_CASE("Testing Phases", "[Phases]")
         CHECK( phases[0].aggregateState() == AggregateState::Solid );
         CHECK( phases[0].activityModel() );
         CHECK( phases[0].idealActivityModel() );
+    }
+
+    SECTION("Testing bad use of GenericPhasesGenerator")
+    {
+        GenericPhasesGenerator generator;
+
+        CHECK_THROWS( generator.convert(db, {}) ); // no species nor elements provided!
     }
 
     //=================================================================================================================


### PR DESCRIPTION
This PR introduces checks to prevent definition of phases and chemical systems without species. This is related to the reported issue #264.

Fixes #264 