### PR TITLE
Using `Requires<Condition> = true` instead of `EnableIf<Condition>...` as SFINAE trick.

### DIFF
--- a/Reaktoro/Common/Algorithms.hpp
+++ b/Reaktoro/Common/Algorithms.hpp
@@ -231,7 +231,7 @@ auto sum(std::size_t iend, const Function& f)
 }
 
 /// Return the sum `f(inds[0]) + ... + f(inds[inds.size() - 1])` for a given function `f`.
-template<typename Indices, typename Function, EnableIf<!isArithmetic<Indices>>...>
+template<typename Indices, typename Function, Requires<!isArithmetic<Indices>> = true>
 auto sum(const Indices& inds, const Function& f)
 {
     using T = std::invoke_result_t<Function, std::size_t>;

--- a/Reaktoro/Common/Memoization.hpp
+++ b/Reaktoro/Common/Memoization.hpp
@@ -165,7 +165,7 @@ auto memoize(Fn<Ret(Args...)> f) -> Fn<Ret(Args...)>
 }
 
 /// Return a memoized version of given function `f`.
-template<typename Fun, EnableIf<!isFunction<Fun>>...>
+template<typename Fun, Requires<!isFunction<Fun>> = true>
 auto memoize(Fun f)
 {
     return memoize(asFunction(f));
@@ -191,7 +191,7 @@ auto memoizeLast(Fn<Ret(Args...)> f) -> Fn<Ret(Args...)>
 }
 
 /// Return a memoized version of given function `f` that caches only the arguments used in the last call.
-template<typename Fun, EnableIf<!isFunction<Fun>>...>
+template<typename Fun, Requires<!isFunction<Fun>> = true>
 auto memoizeLast(Fun f)
 {
     return memoizeLast(asFunction(f));
@@ -223,7 +223,7 @@ auto memoizeLastUsingRef(Fn<void(RetRef, Args...)> f) -> Fn<void(RetRef, Args...
 /// Return a memoized version of given function `f` that caches only the arguments used in the last call./// Return a memoized version of given function `f` that caches only the arguments used in the last call.
 /// This overload is used when `f` is a lambda function or free function.
 /// Use `memoizeLastUsingRef<Ret>(f)` to explicitly specify the `Ret` type.
-template<typename Ret, typename Fun, EnableIf<!isFunction<Fun>>...>
+template<typename Ret, typename Fun, Requires<!isFunction<Fun>> = true>
 auto memoizeLastUsingRef(Fun f)
 {
     return memoizeLastUsingRef<Ret>(asFunction(f));
@@ -240,7 +240,7 @@ auto memoizeLastUsingRef(Fn<void(Ret&, Args...)> f) -> Fn<void(Ret&, Args...)>
 /// Return a memoized version of given function `f` that caches only the arguments used in the last call.
 /// This overload is used when `f` is a lambda function or free function.
 /// Use `memoizeLastUsingRef(f)` to implicitly specify that `RetRef` is `Ret&`.
-template<typename Fun, EnableIf<!isFunction<Fun>>...>
+template<typename Fun, Requires<!isFunction<Fun>> = true>
 auto memoizeLastUsingRef(Fun f)
 {
     return memoizeLastUsingRef(asFunction(f));

--- a/Reaktoro/Common/TraitsUtils.hpp
+++ b/Reaktoro/Common/TraitsUtils.hpp
@@ -26,6 +26,9 @@ namespace Reaktoro {
 template<bool value>
 using EnableIf = std::enable_if_t<value>;
 
+template<bool value>
+using Requires = std::enable_if_t<value, bool>;
+
 template<typename T>
 using Decay = std::decay_t<T>;
 

--- a/Reaktoro/Core/Model.hpp
+++ b/Reaktoro/Core/Model.hpp
@@ -106,7 +106,7 @@ public:
     /// `Model(ModelCalculator<real(real,real)>([](real T, real P) { return A + B*T + C*T*P; }))`
     /// can be replaced with `Model([](real T, real P) { return A + B*T + C*T*P; })`.
     /// @param f A model evaluator or a model calculator function.
-    template<typename Fun, EnableIf<!isFunction<Fun>>...>
+    template<typename Fun, Requires<!isFunction<Fun>> = true>
     Model(const Fun& f)
     : Model(std::function(f))
     // : Model(asFunction(f))

--- a/Reaktoro/Core/Param.hpp
+++ b/Reaktoro/Core/Param.hpp
@@ -125,15 +125,15 @@ inline auto operator-(const Param& p, const Param& q) { return p.value() - q.val
 inline auto operator*(const Param& p, const Param& q) { return p.value() * q.value(); }
 inline auto operator/(const Param& p, const Param& q) { return p.value() / q.value(); }
 
-template<typename T, EnableIf<isNumeric<T>>...> auto operator+(const Param& p, const T& x) { return p.value() + x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator-(const Param& p, const T& x) { return p.value() - x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator*(const Param& p, const T& x) { return p.value() * x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator/(const Param& p, const T& x) { return p.value() / x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator+(const Param& p, const T& x) { return p.value() + x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator-(const Param& p, const T& x) { return p.value() - x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator*(const Param& p, const T& x) { return p.value() * x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator/(const Param& p, const T& x) { return p.value() / x; }
 
-template<typename T, EnableIf<isNumeric<T>>...> auto operator+(const T& x, const Param& p) { return x + p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator-(const T& x, const Param& p) { return x - p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator*(const T& x, const Param& p) { return x * p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator/(const T& x, const Param& p) { return x / p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator+(const T& x, const Param& p) { return x + p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator-(const T& x, const Param& p) { return x - p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator*(const T& x, const Param& p) { return x * p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator/(const T& x, const Param& p) { return x / p.value(); }
 
 } // namespace Reaktoro
 
@@ -150,19 +150,19 @@ inline auto operator> (const Param& p, const Param& q) { return p.value()  > q.v
 inline auto operator<=(const Param& p, const Param& q) { return p.value() <= q.value(); }
 inline auto operator>=(const Param& p, const Param& q) { return p.value() >= q.value(); }
 
-template<typename T, EnableIf<isNumeric<T>>...> auto operator==(const Param& p, const T& x) { return p.value() == x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator!=(const Param& p, const T& x) { return p.value() != x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator< (const Param& p, const T& x) { return p.value()  < x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator> (const Param& p, const T& x) { return p.value()  > x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator<=(const Param& p, const T& x) { return p.value() <= x; }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator>=(const Param& p, const T& x) { return p.value() >= x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator==(const Param& p, const T& x) { return p.value() == x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator!=(const Param& p, const T& x) { return p.value() != x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator< (const Param& p, const T& x) { return p.value()  < x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator> (const Param& p, const T& x) { return p.value()  > x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator<=(const Param& p, const T& x) { return p.value() <= x; }
+template<typename T, Requires<isNumeric<T>> = true> auto operator>=(const Param& p, const T& x) { return p.value() >= x; }
 
-template<typename T, EnableIf<isNumeric<T>>...> auto operator==(const T& x, const Param& p) { return x == p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator!=(const T& x, const Param& p) { return x != p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator< (const T& x, const Param& p) { return x  < p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator> (const T& x, const Param& p) { return x  > p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator<=(const T& x, const Param& p) { return x <= p.value(); }
-template<typename T, EnableIf<isNumeric<T>>...> auto operator>=(const T& x, const Param& p) { return x >= p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator==(const T& x, const Param& p) { return x == p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator!=(const T& x, const Param& p) { return x != p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator< (const T& x, const Param& p) { return x  < p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator> (const T& x, const Param& p) { return x  > p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator<=(const T& x, const Param& p) { return x <= p.value(); }
+template<typename T, Requires<isNumeric<T>> = true> auto operator>=(const T& x, const Param& p) { return x >= p.value(); }
 
 } // namespace Reaktoro
 


### PR DESCRIPTION
This PR introduces necessary changes for Intel C++ compiler 19.1 to understand SFINAE in Reaktoro. The previous use of `EnableIf<Condition>...` was not resulting in correct compilation.