### PR TITLE
Implemented `Warnings` class to disable/enable warnings at global scope

### DIFF
--- a/Reaktoro/Common/Warnings.cpp
+++ b/Reaktoro/Common/Warnings.cpp
@@ -1,0 +1,66 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#include "Warnings.hpp"
+
+// Reaktoro includes
+#include <Reaktoro/Common/Algorithms.hpp>
+#include <Reaktoro/Common/Types.hpp>
+
+namespace Reaktoro {
+
+auto getDisabledWarnings() -> Vec<int>&
+{
+    static thread_local Vec<int> disabled_warnings;
+    return disabled_warnings;
+}
+
+auto Warnings::enable(int warningid) -> bool
+{
+    auto& disabled = getDisabledWarnings();
+    auto pos = std::find(disabled.begin(), disabled.end(), warningid);
+    if(pos < disabled.end())
+    {
+        disabled.erase(pos);
+        return true;
+    }
+    return false;
+}
+
+auto Warnings::disable(int warningid) -> bool
+{
+    auto& disabled = getDisabledWarnings();
+    if(!contains(disabled, warningid))
+    {
+        disabled.push_back(warningid);
+        return true;
+    }
+    return false;
+}
+
+auto Warnings::isEnabled(int warningid) -> bool
+{
+    return !isDisabled(warningid);
+}
+
+auto Warnings::isDisabled(int warningid) -> bool
+{
+    auto const& disabled = getDisabledWarnings();
+    return contains(disabled, warningid);
+}
+
+} // namespace Reaktoro

--- a/Reaktoro/Common/Warnings.hpp
+++ b/Reaktoro/Common/Warnings.hpp
@@ -1,0 +1,41 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace Reaktoro {
+
+/// Used to control warnings in the execution of Reaktoro.
+class Warnings
+{
+public:
+    /// Enable warning with given id.
+    /// @return `false` if given warning id was already enabled; `true` otherwise.
+    static auto enable(int warningid) -> bool;
+
+    /// Disable warning with given id.
+    /// @return `false` if given warning id was already disabled; `true` otherwise.
+    static auto disable(int warningid) -> bool;
+
+    /// Check if warning with given id is enabled.
+    static auto isEnabled(int warningid) -> bool;
+
+    /// Check if warning with given id is disabled.
+    static auto isDisabled(int warningid) -> bool;
+};
+
+} // namespace Reaktoro

--- a/Reaktoro/Common/Warnings.py
+++ b/Reaktoro/Common/Warnings.py
@@ -1,0 +1,41 @@
+# Reaktoro is a unified framework for modeling chemically reactive systems.
+#
+# Copyright © 2014-2022 Allan Leal
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+
+from reaktoro import *
+
+
+def testWarnings():
+
+    assert Warnings.isEnabled(123)  # by default, all warnings are enabled!
+
+    Warnings.disable(123)
+    assert Warnings.isDisabled(123)
+
+    Warnings.enable(123)
+    assert Warnings.isEnabled(123)
+
+    Warnings.disable(124)
+    Warnings.disable(179)
+
+    # Check disabling already disabled warnings return false
+    assert Warnings.disable(124) == False
+    assert Warnings.disable(179) == False
+
+    # Check enabling already enabled warnings return false
+    assert Warnings.enable(897) == False
+    assert Warnings.enable(976) == False

--- a/Reaktoro/Common/Warnings.py.cxx
+++ b/Reaktoro/Common/Warnings.py.cxx
@@ -18,27 +18,16 @@
 // pybind11 includes
 #include <Reaktoro/pybind11.hxx>
 
-void exportConstants(py::module& m);
-void exportInterpolationUtils(py::module& m);
-void exportMemoization(py::module& m);
-void exportParseUtils(py::module& m);
-void exportStringList(py::module& m);
-void exportStringUtils(py::module& m);
-void exportTypes(py::module& m);
-void exportUnits(py::module& m);
-void exportWarnings(py::module& m);
-void exportYAML(py::module& m);
+// Reaktoro includes
+#include <Reaktoro/Common/Warnings.hpp>
+using namespace Reaktoro;
 
-void exportCommon(py::module& m)
+void exportWarnings(py::module& m)
 {
-    exportConstants(m);
-    exportInterpolationUtils(m);
-    exportMemoization(m);
-    exportParseUtils(m);
-    exportStringList(m);
-    exportStringUtils(m);
-    exportUnits(m);
-    exportTypes(m);
-    exportWarnings(m);
-    exportYAML(m);
+    py::class_<Warnings>(m, "Warnings")
+        .def_static("enable", &Warnings::enable, "Enable warning with given id.")
+        .def_static("disable", &Warnings::disable, "Disable warning with given id.")
+        .def_static("isEnabled", &Warnings::isEnabled, "Check if warning with given id is enabled.")
+        .def_static("isDisabled", &Warnings::isDisabled, "Check if warning with given id is disabled.")
+        ;
 }

--- a/Reaktoro/Common/Warnings.test.cxx
+++ b/Reaktoro/Common/Warnings.test.cxx
@@ -1,0 +1,45 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// Catch includes
+#include <catch2/catch.hpp>
+
+// Reaktoro includes
+#include <Reaktoro/Common/Warnings.hpp>
+using namespace Reaktoro;
+
+TEST_CASE("Testing Warnings", "[Warnings]")
+{
+    CHECK( Warnings::isEnabled(123) ); // by default, all warnings are enabled!
+
+    Warnings::disable(123);
+    CHECK( Warnings::isDisabled(123) );
+
+    Warnings::enable(123);
+    CHECK( Warnings::isEnabled(123) );
+
+    Warnings::disable(124);
+    Warnings::disable(179);
+
+    // Check disabling already disabled warnings return false
+    CHECK_FALSE( Warnings::disable(124) );
+    CHECK_FALSE( Warnings::disable(179) );
+
+    // Check enabling already enabled warnings return false
+    CHECK_FALSE( Warnings::enable(897) );
+    CHECK_FALSE( Warnings::enable(976) );
+}

--- a/Reaktoro/Utils/Material.py
+++ b/Reaktoro/Utils/Material.py
@@ -13,7 +13,7 @@
 # Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this library. If not, see <http:#www.gnu.org/licenses/>.
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 
 from reaktoro import *


### PR DESCRIPTION
Implemented class `Warnings` to disable/enable warnings at a global scope. Useful to prevent repeated warnings from appearing when, say, a function containing a warning is evaluated many times. By calling `Warnings::disable(123);`  (C++) or `Warnings.disable(123)` (Python), the emitted warning with id `123` will be ommited. 