### PR TITLE
Fix saturation index definition in class `AqueousProps`

### DIFF
--- a/Reaktoro/Common/Warnings.cpp
+++ b/Reaktoro/Common/Warnings.cpp
@@ -1,0 +1,66 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#include "Warnings.hpp"
+
+// Reaktoro includes
+#include <Reaktoro/Common/Algorithms.hpp>
+#include <Reaktoro/Common/Types.hpp>
+
+namespace Reaktoro {
+
+auto getDisabledWarnings() -> Vec<int>&
+{
+    static thread_local Vec<int> disabled_warnings;
+    return disabled_warnings;
+}
+
+auto Warnings::enable(int warningid) -> bool
+{
+    auto& disabled = getDisabledWarnings();
+    auto pos = std::find(disabled.begin(), disabled.end(), warningid);
+    if(pos < disabled.end())
+    {
+        disabled.erase(pos);
+        return true;
+    }
+    return false;
+}
+
+auto Warnings::disable(int warningid) -> bool
+{
+    auto& disabled = getDisabledWarnings();
+    if(!contains(disabled, warningid))
+    {
+        disabled.push_back(warningid);
+        return true;
+    }
+    return false;
+}
+
+auto Warnings::isEnabled(int warningid) -> bool
+{
+    return !isDisabled(warningid);
+}
+
+auto Warnings::isDisabled(int warningid) -> bool
+{
+    auto const& disabled = getDisabledWarnings();
+    return contains(disabled, warningid);
+}
+
+} // namespace Reaktoro

--- a/Reaktoro/Common/Warnings.hpp
+++ b/Reaktoro/Common/Warnings.hpp
@@ -1,0 +1,41 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace Reaktoro {
+
+/// Used to control warnings in the execution of Reaktoro.
+class Warnings
+{
+public:
+    /// Enable warning with given id.
+    /// @return `false` if given warning id was already enabled; `true` otherwise.
+    static auto enable(int warningid) -> bool;
+
+    /// Disable warning with given id.
+    /// @return `false` if given warning id was already disabled; `true` otherwise.
+    static auto disable(int warningid) -> bool;
+
+    /// Check if warning with given id is enabled.
+    static auto isEnabled(int warningid) -> bool;
+
+    /// Check if warning with given id is disabled.
+    static auto isDisabled(int warningid) -> bool;
+};
+
+} // namespace Reaktoro

--- a/Reaktoro/Common/Warnings.py
+++ b/Reaktoro/Common/Warnings.py
@@ -1,0 +1,41 @@
+# Reaktoro is a unified framework for modeling chemically reactive systems.
+#
+# Copyright © 2014-2022 Allan Leal
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+
+from reaktoro import *
+
+
+def testWarnings():
+
+    assert Warnings.isEnabled(123)  # by default, all warnings are enabled!
+
+    Warnings.disable(123)
+    assert Warnings.isDisabled(123)
+
+    Warnings.enable(123)
+    assert Warnings.isEnabled(123)
+
+    Warnings.disable(124)
+    Warnings.disable(179)
+
+    # Check disabling already disabled warnings return false
+    assert Warnings.disable(124) == False
+    assert Warnings.disable(179) == False
+
+    # Check enabling already enabled warnings return false
+    assert Warnings.enable(897) == False
+    assert Warnings.enable(976) == False

--- a/Reaktoro/Common/Warnings.py.cxx
+++ b/Reaktoro/Common/Warnings.py.cxx
@@ -18,27 +18,16 @@
 // pybind11 includes
 #include <Reaktoro/pybind11.hxx>
 
-void exportConstants(py::module& m);
-void exportInterpolationUtils(py::module& m);
-void exportMemoization(py::module& m);
-void exportParseUtils(py::module& m);
-void exportStringList(py::module& m);
-void exportStringUtils(py::module& m);
-void exportTypes(py::module& m);
-void exportUnits(py::module& m);
-void exportWarnings(py::module& m);
-void exportYAML(py::module& m);
+// Reaktoro includes
+#include <Reaktoro/Common/Warnings.hpp>
+using namespace Reaktoro;
 
-void exportCommon(py::module& m)
+void exportWarnings(py::module& m)
 {
-    exportConstants(m);
-    exportInterpolationUtils(m);
-    exportMemoization(m);
-    exportParseUtils(m);
-    exportStringList(m);
-    exportStringUtils(m);
-    exportUnits(m);
-    exportTypes(m);
-    exportWarnings(m);
-    exportYAML(m);
+    py::class_<Warnings>(m, "Warnings")
+        .def_static("enable", &Warnings::enable, "Enable warning with given id.")
+        .def_static("disable", &Warnings::disable, "Disable warning with given id.")
+        .def_static("isEnabled", &Warnings::isEnabled, "Check if warning with given id is enabled.")
+        .def_static("isDisabled", &Warnings::isDisabled, "Check if warning with given id is disabled.")
+        ;
 }

--- a/Reaktoro/Common/Warnings.test.cxx
+++ b/Reaktoro/Common/Warnings.test.cxx
@@ -1,0 +1,45 @@
+// Reaktoro is a unified framework for modeling chemically reactive systems.
+//
+// Copyright © 2014-2022 Allan Leal
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+// Catch includes
+#include <catch2/catch.hpp>
+
+// Reaktoro includes
+#include <Reaktoro/Common/Warnings.hpp>
+using namespace Reaktoro;
+
+TEST_CASE("Testing Warnings", "[Warnings]")
+{
+    CHECK( Warnings::isEnabled(123) ); // by default, all warnings are enabled!
+
+    Warnings::disable(123);
+    CHECK( Warnings::isDisabled(123) );
+
+    Warnings::enable(123);
+    CHECK( Warnings::isEnabled(123) );
+
+    Warnings::disable(124);
+    Warnings::disable(179);
+
+    // Check disabling already disabled warnings return false
+    CHECK_FALSE( Warnings::disable(124) );
+    CHECK_FALSE( Warnings::disable(179) );
+
+    // Check enabling already enabled warnings return false
+    CHECK_FALSE( Warnings::enable(897) );
+    CHECK_FALSE( Warnings::enable(976) );
+}

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.hpp
@@ -124,29 +124,25 @@ public:
     /// could form when the aqueous solution is saturated with respect to them.
     auto saturationSpecies() const -> SpeciesList;
 
-    /// Return the saturation index of a given species.
+    /// Return the saturation index (@eq{\mathrm{SI} \equiv \log \Omega = \log \mathrm{IAP}/K}) of a non-aqueous species.
     /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
     auto saturationIndex(const StringOrIndex& species) const -> real;
-
-    /// Return the saturation index of a given species (in natural log).
-    /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
-    auto saturationIndexLn(const StringOrIndex& species) const -> real;
-
-    /// Return the saturation index of a given species (in log base 10).
-    /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
-    auto saturationIndexLg(const StringOrIndex& species) const -> real;
 
     /// Return the saturation indices of all non-aqueous species.
     /// These non-aqueous species can be obtained with @ref saturationSpecies.
     auto saturationIndices() const -> ArrayXr;
 
-    /// Return the saturation indices of all non-aqueous species (in natural log).
-    /// These non-aqueous species can be obtained with @ref saturationSpecies.
-    auto saturationIndicesLn() const -> ArrayXr;
+    /// Return the saturation ratio (@eq{\mathrm{SR} \equiv \Omega = \mathrm{IAP}/K}) of a non-aqueous species.
+    /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
+    auto saturationRatio(const StringOrIndex& species) const -> real;
 
-    /// Return the saturation indices of all non-aqueous species (in log base 10).
+    /// Return the saturation ratios of all non-aqueous species.
     /// These non-aqueous species can be obtained with @ref saturationSpecies.
-    auto saturationIndicesLg() const -> ArrayXr;
+    auto saturationRatios() const -> ArrayXr;
+
+    /// Return the saturation ratios of all non-aqueous species (in natural log).
+    /// These non-aqueous species can be obtained with @ref saturationSpecies.
+    auto saturationRatiosLn() const -> ArrayXr;
 
     /// Return the underlying Phase object for the aqueous phase.
     auto phase() const -> const Phase&;
@@ -156,6 +152,29 @@ public:
 
     /// Output the properties of the aqueous phase to a file.
     auto output(const String& filename) const -> void;
+
+    // DEPRECATED METHODS : TO BE REMOVED IN THE NEAR FUTURE
+
+    /// Return the saturation index of a given species (in natural log).
+    /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
+    [[deprecated("Rely on the use of saturationIndex(species) instead.")]]
+    auto saturationIndexLn(const StringOrIndex& species) const -> real;
+
+    /// Return the saturation index of a given species (in log base 10).
+    /// @param species The name or index of the non-aqueous species in the list of species returned by @ref saturationSpecies.
+    [[deprecated("Rely on the use of saturationIndex(species) instead.")]]
+    auto saturationIndexLg(const StringOrIndex& species) const -> real;
+
+    /// Return the saturation indices of all non-aqueous species (in natural log).
+    /// These non-aqueous species can be obtained with @ref saturationSpecies.
+    [[deprecated("Rely on the use of saturationIndices() instead.")]]
+    auto saturationIndicesLn() const -> ArrayXr;
+
+    /// Return the saturation indices of all non-aqueous species (in log base 10).
+    /// These non-aqueous species can be obtained with @ref saturationSpecies.
+    [[deprecated("Rely on the use of saturationIndices() instead.")]]
+    auto saturationIndicesLg() const -> ArrayXr;
+
 
 private:
     struct Impl;

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.py.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.py.cxx
@@ -29,6 +29,11 @@ using namespace Reaktoro;
 
 void exportAqueousProps(py::module& m)
 {
+    auto saturationIndexLn   = [](AqueousProps const& self, StringOrIndex const& species) -> real { errorif(true, "Method AqueousProps::saturationIndexLn has been deprecated. Rely on the use of saturationIndex(species) instead."); return {}; };
+    auto saturationIndexLg   = [](AqueousProps const& self, StringOrIndex const& species) -> real { errorif(true, "Method AqueousProps::saturationIndexLg has been deprecated. Rely on the use of saturationIndex(species) instead."); return {}; };
+    auto saturationIndicesLn = [](AqueousProps const& self) -> real { errorif(true, "Method AqueousProps::saturationIndicesLn has been deprecated. Rely on the use of saturationIndices() instead."); return {}; };
+    auto saturationIndicesLg = [](AqueousProps const& self) -> real { errorif(true, "Method AqueousProps::saturationIndicesLg has been deprecated. Rely on the use of saturationIndices() instead."); return {}; };
+
     py::class_<AqueousProps>(m, "AqueousProps")
         .def(py::init<const ChemicalSystem&>())
         .def(py::init<const ChemicalState&>())
@@ -52,15 +57,21 @@ void exportAqueousProps(py::module& m)
         .def("Eh", &AqueousProps::Eh, "Return the reduction potential of the aqueous phase (in V).")
         .def("alkalinity", &AqueousProps::alkalinity, "Return the total alkalinity of the aqueous phase (in eq/L).")
         .def("saturationSpecies", &AqueousProps::saturationSpecies, "Return the non-aqueous species that could be formed from the aqueous solution.")
-        .def("saturationIndex", &AqueousProps::saturationIndex, "Return the saturation index of a given species.")
-        .def("saturationIndexLn", &AqueousProps::saturationIndexLn, "Return the saturation index of a given species (in natural log).")
-        .def("saturationIndexLg", &AqueousProps::saturationIndexLg, "Return the saturation index of a given species (in log base 10).")
+        .def("saturationIndex", &AqueousProps::saturationIndex, "Return the saturation index SI ≡ log(Ω) = log(IAP/K) of a non-aqueous species.")
         .def("saturationIndices", &AqueousProps::saturationIndices, "Return the saturation indices of all non-aqueous species.")
-        .def("saturationIndicesLn", &AqueousProps::saturationIndicesLn, "Return the saturation indices of all non-aqueous species (in natural log).")
-        .def("saturationIndicesLg", &AqueousProps::saturationIndicesLg, "Return the saturation indices of all non-aqueous species (in log base 10).")
+        .def("saturationRatio", &AqueousProps::saturationRatio, "Return the saturation ratio SR ≡ Ω = IAP/K of a non-aqueous species.")
+        .def("saturationRatios", &AqueousProps::saturationRatios, "Return the saturation ratios of all non-aqueous species.")
+        .def("saturationRatiosLn", &AqueousProps::saturationRatiosLn, "Return the saturation ratios of all non-aqueous species (in natural log).")
         .def("phase", &AqueousProps::phase, return_internal_ref, "Return the underlying Phase object for the aqueous phase.")
         .def("output", py::overload_cast<std::ostream&>(&AqueousProps::output, py::const_), "Output the properties of the aqueous phase to a stream.")
         .def("output", py::overload_cast<const String&>(&AqueousProps::output, py::const_), "Output the properties of the aqueous phase to a file.")
         .def("__repr__", [](const AqueousProps& self) { std::stringstream ss; ss << self; return ss.str(); })
+
+        // DEPRECATED METHODS : TO BE REMOVED IN THE NEAR FUTURE
+
+        .def("saturationIndexLn", saturationIndexLn, "Return the saturation index of a given species (in natural log).")
+        .def("saturationIndexLg", saturationIndexLg, "Return the saturation index of a given species (in log base 10).")
+        .def("saturationIndicesLn", saturationIndicesLn, "Return the saturation indices of all non-aqueous species (in natural log).")
+        .def("saturationIndicesLg", saturationIndicesLg, "Return the saturation indices of all non-aqueous species (in log base 10).")
         ;
 }

--- a/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
+++ b/Reaktoro/Thermodynamics/Aqueous/AqueousProps.test.cxx
@@ -140,8 +140,8 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
         CHECK( aqprops.elementMolality("Cl") == Approx(388.559) );
         CHECK( aqprops.elementMolality("Ca") == Approx(111.017) );
 
-        // Check saturation indices of the non-aqueous species
-        auto lnOmega = aqprops.saturationIndicesLn();
+        // Check saturation ratios of the non-aqueous species
+        auto lnOmega = aqprops.saturationRatiosLn();
 
         CHECK( lnOmega[0]  == Approx(-1.474090) );
         CHECK( lnOmega[1]  == Approx(-1.447940) );
@@ -171,7 +171,7 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
         aqprops.setActivityModel("CaMg(CO3)2(s)", ActivityModelIdealSolution(StateOfMatter::Solid));
         aqprops.setActivityModel("SiO2(s)"      , ActivityModelIdealSolution(StateOfMatter::Solid));
 
-        lnOmega = aqprops.saturationIndicesLn();
+        lnOmega = aqprops.saturationRatiosLn();
 
         CHECK( lnOmega[0]  == Approx(0.031383400) );
         CHECK( lnOmega[1]  == Approx(0.052984200) );
@@ -185,13 +185,11 @@ TEST_CASE("Testing AqueousProps class", "[AqueousProps]")
         CHECK( lnOmega[9]  == Approx(0.102009000) );
         CHECK( lnOmega[10] == Approx(0.049714300) );
 
-        CHECK( aqprops.saturationIndexLn(5) == Approx(0.000339846) );
-        CHECK( aqprops.saturationIndexLg(5) == Approx(0.000339846/ln10) );
-        CHECK( aqprops.saturationIndex(5)   == Approx(exp(0.000339846)) );
+        CHECK( aqprops.saturationRatio(5)       == Approx(exp(0.000339846)) );
+        CHECK( aqprops.saturationRatio("CO(g)") == Approx(exp(0.000339846)) );
 
-        CHECK( aqprops.saturationIndexLn("CO(g)") == Approx(0.000339846) );
-        CHECK( aqprops.saturationIndexLg("CO(g)") == Approx(0.000339846/ln10) );
-        CHECK( aqprops.saturationIndex("CO(g)")   == Approx(exp(0.000339846)) );
+        CHECK( aqprops.saturationIndex(5)       == Approx(0.000339846/ln10) );
+        CHECK( aqprops.saturationIndex("CO(g)") == Approx(0.000339846/ln10) );
     }
 
     SECTION("Testing when state is a brine")

--- a/Reaktoro/Utils/Material.py
+++ b/Reaktoro/Utils/Material.py
@@ -13,7 +13,7 @@
 # Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this library. If not, see <http:#www.gnu.org/licenses/>.
+# along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 
 from reaktoro import *


### PR DESCRIPTION
Method `AqueousProps::saturationIndex` is now computing saturation index as:

$\mathrm{SI} \equiv \log \Omega = \log \mathrm{IAP}/K$

instead of just $\mathrm{IAP}/K$. For this quantity, one now needs to use method `AqueousProps::saturationRatio`, which computes the saturation ratio of a non-aqueous species as:

$\mathrm{SR} \equiv \Omega = \mathrm{IAP}/K$

