### PR TITLE
Remove `clcache` as dependency on Windows

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -10,7 +10,6 @@ dependencies:
   - catch2 =2
   - ccache  # [unix]
   - clangxx_osx-64  # [osx]
-  - clcache  # [win]
   - cmake
   - cpp-tabulate
   - doxygen =1.9.1  # [linux]


### PR DESCRIPTION
The last build of `clcache` on conda-forge was two years ago. This build is now creating conflicts when resolving conda dependencies.