### PR TITLE
Fix wrong check for K (Kelvin) in a pressure function

### DIFF
--- a/Reaktoro/Equilibrium/EquilibriumProblem.cpp
+++ b/Reaktoro/Equilibrium/EquilibriumProblem.cpp
@@ -66,7 +66,7 @@ auto EquilibriumProblem::startWithPressure(real value) -> void
 
 auto EquilibriumProblem::startWithPressure(real value, Chars unit) -> void
 {
-    auto converted = units::convert(value, unit, "K");
+    auto converted = units::convert(value, unit, "Pa");
     errorif(converted <= 0.0, "EquilibriumProblem::startWithPressure requires a positive pressure value in Pa, but the given value was ", value, " ", unit);
     m_initial_pressure = converted;
 }


### PR DESCRIPTION
Function `EquilibriumProblem::startWithPressure(real value, Chars unit)` tries to convert `unit` to `"K"` (Kelvin), which is a temperature unit, not a pressure one.

As pressures are handled in `"Pa"` in other methods in `EquilibriumProblem`, conversion to `"Pa"` is proposed as a fix.