### PR TITLE
Improvements in partial molar volume calculations

### DIFF
--- a/Reaktoro/Core/ActivityProps.hpp
+++ b/Reaktoro/Core/ActivityProps.hpp
@@ -57,14 +57,17 @@ namespace Reaktoro {
 template<template<typename> typename TypeOp>
 struct ActivityPropsBase
 {
-    /// The corrective molar volume of the phase (in m3/mol).
+    /// The corrective molar volume of the phase (in m³/mol).
     TypeOp<real> Vx;
 
-    /// The temperature derivative of the corrective molar volume at constant pressure (in m3/(mol*K)).
+    /// The derivative of the corrective molar volume with respect to temperature at constant pressure and species mole fractions (in m³/(mol⋅K)).
     TypeOp<real> VxT;
 
-    /// The pressure derivative of the corrective molar volume at constant temperature (in m3/(mol*Pa)).
+    /// The derivative of the corrective molar volume with respect to pressure at constant temperature and species mole fractions (in m³/(mol⋅Pa)).
     TypeOp<real> VxP;
+
+    /// The derivatives of the corrective molar volume with respect to species mole fractions at constant temperature and pressure (in m³/mol).
+    TypeOp<ArrayXr> Vxi;
 
     /// The corrective molar Gibbs energy of the phase (in units of J/mol).
     TypeOp<real> Gx;
@@ -72,11 +75,8 @@ struct ActivityPropsBase
     /// The corrective molar enthalpy of the phase (in units of J/mol).
     TypeOp<real> Hx;
 
-    /// The corrective molar isobaric heat capacity of the phase (in units of J/(mol*K)).
+    /// The corrective molar isobaric heat capacity of the phase (in units of J/(mol⋅K)).
     TypeOp<real> Cpx;
-
-    /// The partial molar volumes of the species in the phase (in m3/mol).
-    TypeOp<ArrayXr> Vi;
 
     /// The activity coefficients (natural log) of the species in the phase.
     TypeOp<ArrayXr> ln_g;
@@ -111,10 +111,10 @@ struct ActivityPropsBase
         Vx    = other.Vx;
         VxT   = other.VxT;
         VxP   = other.VxP;
+        Vxi   = other.Vxi;
         Gx    = other.Gx;
         Hx    = other.Hx;
         Cpx   = other.Cpx;
-        Vi    = other.Vi;
         ln_g  = other.ln_g;
         ln_a  = other.ln_a;
         som   = other.som;
@@ -126,14 +126,14 @@ struct ActivityPropsBase
     template<template<typename> typename OtherTypeOp>
     operator ActivityPropsBase<OtherTypeOp>()
     {
-        return { Vx, VxT, VxP, Gx, Hx, Cpx, Vi, ln_g, ln_a, som, extra };
+        return { Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, som, extra };
     }
 
     /// Convert this ActivityPropsBase object into another.
     template<template<typename> typename OtherTypeOp>
     operator ActivityPropsBase<OtherTypeOp>() const
     {
-        return { Vx, VxT, VxP, Gx, Hx, Cpx, Vi, ln_g, ln_a, som, extra };
+        return { Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, som, extra };
     }
 
     /// Create a ActivityPropsBase object with given number of species.
@@ -148,7 +148,7 @@ struct ActivityPropsBase
         props.Gx  = 0.0;
         props.Hx  = 0.0;
         props.Cpx = 0.0;
-        props.Vi = ArrayXr::Zero(numspecies);
+        props.Vxi  = ArrayXr::Zero(numspecies);
         props.ln_g = ArrayXr::Zero(numspecies);
         props.ln_a = ArrayXr::Zero(numspecies);
         return props;

--- a/Reaktoro/Core/ChemicalProps.cpp
+++ b/Reaktoro/Core/ChemicalProps.cpp
@@ -57,10 +57,10 @@ ChemicalProps::ChemicalProps(ChemicalSystem const& system)
     Vx   = ArrayXr::Zero(K);
     VxT  = ArrayXr::Zero(K);
     VxP  = ArrayXr::Zero(K);
+    Vxi  = ArrayXr::Zero(N);
     Gx   = ArrayXr::Zero(K);
     Hx   = ArrayXr::Zero(K);
     Cpx  = ArrayXr::Zero(K);
-    Vi   = ArrayXr::Zero(N);
     ln_g = ArrayXr::Zero(N);
     ln_a = ArrayXr::Zero(N);
     u    = ArrayXr::Zero(N);
@@ -105,13 +105,13 @@ auto ChemicalProps::update(real const& T0, real const& P0, ArrayXrConstRef n0) -
 auto ChemicalProps::update(ArrayXrConstRef data) -> void
 {
     mstateid += 1;
-    ArraySerialization::deserialize(data, T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    ArraySerialization::deserialize(data, T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::update(ArrayXdConstRef data) -> void
 {
     mstateid += 1;
-    ArraySerialization::deserialize(data, T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    ArraySerialization::deserialize(data, T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::updateIdeal(ChemicalState const& state) -> void
@@ -145,24 +145,24 @@ auto ChemicalProps::updateIdeal(real const& T0, real const& P0, ArrayXrConstRef 
 
 auto ChemicalProps::serialize(ArrayStream<real>& stream) const -> void
 {
-    stream.from(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    stream.from(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::serialize(ArrayStream<double>& stream) const -> void
 {
-    stream.from(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    stream.from(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::deserialize(const ArrayStream<real>& stream) -> void
 {
     mstateid += 1;
-    stream.to(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    stream.to(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::deserialize(const ArrayStream<double>& stream) -> void
 {
     mstateid += 1;
-    stream.to(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Gx, Hx, Cpx, ln_g, ln_a, u);
+    stream.to(T, P, n, Ts, Ps, nsum, msum, x, G0, H0, V0, VT0, VP0, Cp0, Vx, VxT, VxP, Vxi, Gx, Hx, Cpx, ln_g, ln_a, u);
 }
 
 auto ChemicalProps::stateid() const -> Index
@@ -203,10 +203,10 @@ auto ChemicalProps::phasePropsRef(StringOrIndex phaseid) -> ChemicalPropsPhaseRe
         Vx[iphase],
         VxT[iphase],
         VxP[iphase],
+        Vxi.segment(begin, size),
         Gx[iphase],
         Hx[iphase],
         Cpx[iphase],
-        Vi.segment(begin,size),
         ln_g.segment(begin, size),
         ln_a.segment(begin, size),
         u.segment(begin, size),
@@ -533,9 +533,9 @@ auto ChemicalProps::speciesChemicalPotentials() const -> ArrayXrConstRef
     return u;
 }
 
-auto ChemicalProps::speciesPartialMolarVolumes() const -> ArrayXrConstRef
+auto ChemicalProps::speciesPartialMolarVolumes() const -> ArrayXr
 {
-    return Vi;
+    return V0 + Vxi;
 }
 
 auto ChemicalProps::speciesStandardVolumes() const -> ArrayXrConstRef

--- a/Reaktoro/Core/ChemicalProps.hpp
+++ b/Reaktoro/Core/ChemicalProps.hpp
@@ -289,7 +289,7 @@ public:
     auto speciesChemicalPotentials() const -> ArrayXrConstRef;
 
     /// Return the partial molar volumes of the species in the system (in m³/mol).
-    auto speciesPartialMolarVolumes() const->ArrayXrConstRef;
+    auto speciesPartialMolarVolumes() const-> ArrayXr;
 
     /// Return the standard partial molar volumes of the species in the system (in m³/mol).
     auto speciesStandardVolumes() const -> ArrayXrConstRef;
@@ -526,11 +526,14 @@ private:
     /// The corrective molar volume of each phase in the system (in m³/mol).
     ArrayXr Vx;
 
-    /// The temperature derivative at constant pressure of the corrective molar volume of each phase in the system (in m³/(mol·K)).
+    /// The derivative of the corrective molar volume of each phase in the system with respect to temperature at constant pressure and species mole fractions (in m³/(mol⋅K)).
     ArrayXr VxT;
 
-    /// The pressure derivative at constant temperature of the corrective molar volume of each phase in the system (in m³/(mol·Pa)).
+    /// The derivative of the corrective molar volume of each phase in the system with respect to pressure at constant temperature and species mole fractions (in m³/(mol⋅Pa)).
     ArrayXr VxP;
+
+    /// The derivatives of the corrective molar volume of each phase in the system with respect to species mole fractions at constant temperature and pressure (in m³/mol).
+    ArrayXr Vxi;
 
     /// The corrective molar Gibbs energy of each phase in the system (in J/mol).
     ArrayXr Gx;
@@ -540,9 +543,6 @@ private:
 
     /// The corrective molar isobaric heat capacity of each phase in the system (in J/(mol·K)).
     ArrayXr Cpx;
-
-    /// The partial molar volumes of the species in the phase (in m3/mol).
-    ArrayXr Vi;
 
     /// The activity coefficients (natural log) of the species in the system.
     ArrayXr ln_g;

--- a/Reaktoro/Models/ActivityModels/ActivityModelCubicEOS.cpp
+++ b/Reaktoro/Models/ActivityModels/ActivityModelCubicEOS.cpp
@@ -85,10 +85,10 @@ auto activityModelCubicEOS(SpeciesList const& specieslist, CubicEOS::EquationMod
         props.Vx   = cprops.V;
         props.VxT  = cprops.VT;
         props.VxP  = cprops.VP;
+        props.Vxi  = cprops.Vi;
         props.Gx   = cprops.Gres;
         props.Hx   = cprops.Hres;
         props.Cpx  = cprops.Cpres;
-        props.Vi   = cprops.Vi;
         props.ln_g = cprops.ln_phi;
         props.ln_a = cprops.ln_phi + log(x) + log(Pbar);
         props.som  = cprops.som;


### PR DESCRIPTION
This pull request implements some code organization to better accommodate the calculation of partial molar volumes of the species following pull request #312.

It also corrects the equation in `ChemicalProps::speciesPartialMolarVolumes`, in which the standard partial molar volumes of the species are not being used. This PR implements the equation below instead:

![image](https://github.com/reaktoro/reaktoro/assets/5825588/764f793a-4eed-4b16-9089-9ae8e91b5503)
