### PR TITLE
Fix bug with static variables in two activity models

### DIFF
--- a/Reaktoro/Models/ActivityModels/ActivityModelDuanSun.cpp
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDuanSun.cpp
@@ -88,6 +88,15 @@ auto ActivityModelDuanSun(String gas) -> ActivityModelGenerator
         // The index of the dissolved gas in the aqueous phase.
         const auto igas = species.indexWithFormula(gas);
 
+        // the local indices of some charged species among all charged species
+        const auto aqmix = AqueousMixture(species);
+        const auto iNa  = aqmix.charged().findWithFormula("Na+");
+        const auto iK   = aqmix.charged().findWithFormula("K+");
+        const auto iCa  = aqmix.charged().findWithFormula("Ca++");
+        const auto iMg  = aqmix.charged().findWithFormula("Mg++");
+        const auto iCl  = aqmix.charged().findWithFormula("Cl-");
+        const auto iSO4 = aqmix.charged().findWithFormula("SO4--");
+
         ActivityModel fn = [=](ActivityPropsRef props, ActivityModelArgs args)
         {
             // Check AqueousMixture and AqueousMixtureState are available in props.extra
@@ -100,14 +109,6 @@ auto ActivityModelDuanSun(String gas) -> ActivityModelGenerator
             // The aqueous mixture and its state exported by a base aqueous activity model.
             const auto& mixture = *std::any_cast<SharedPtr<AqueousMixture> const&>(mixtureit->second);
             const auto& state = *std::any_cast<SharedPtr<AqueousMixtureState> const&>(stateit->second);
-
-            // The local indices of some charged species among all charged species
-            static const auto iNa  = mixture.charged().findWithFormula("Na+");
-            static const auto iK   = mixture.charged().findWithFormula("K+");
-            static const auto iCa  = mixture.charged().findWithFormula("Ca++");
-            static const auto iMg  = mixture.charged().findWithFormula("Mg++");
-            static const auto iCl  = mixture.charged().findWithFormula("Cl-");
-            static const auto iSO4 = mixture.charged().findWithFormula("SO4--");
 
             const auto& T  = state.T;
             const auto& P  = state.P;

--- a/Reaktoro/Models/ActivityModels/ActivityModelRumpf.cpp
+++ b/Reaktoro/Models/ActivityModels/ActivityModelRumpf.cpp
@@ -31,6 +31,14 @@ auto ActivityModelRumpf(String gas) -> ActivityModelGenerator
         // The index of the dissolved gas in the aqueous phase.
         const auto igas = species.indexWithFormula(gas);
 
+        // the local indices of some charged species among all charged species
+        const auto aqmix = AqueousMixture(species);
+        const auto iNa  = aqmix.charged().findWithFormula("Na+");
+        const auto iK   = aqmix.charged().findWithFormula("K+");
+        const auto iCa  = aqmix.charged().findWithFormula("Ca++");
+        const auto iMg  = aqmix.charged().findWithFormula("Mg++");
+        const auto iCl  = aqmix.charged().findWithFormula("Cl-");
+
         ActivityModel fn = [=](ActivityPropsRef props, ActivityModelArgs args)
         {
             // Check AqueousMixture and AqueousMixtureState are available in props.extra
@@ -43,13 +51,6 @@ auto ActivityModelRumpf(String gas) -> ActivityModelGenerator
             // The aqueous mixture and its state exported by a base aqueous activity model.
             const auto& mixture = *std::any_cast<SharedPtr<AqueousMixture> const&>(mixtureit->second);
             const auto& state = *std::any_cast<SharedPtr<AqueousMixtureState> const&>(stateit->second);
-
-            // The local indices of some charged species among all charged species
-            static const auto iNa  = mixture.charged().findWithFormula("Na+");
-            static const auto iK   = mixture.charged().findWithFormula("K+");
-            static const auto iCa  = mixture.charged().findWithFormula("Ca++");
-            static const auto iMg  = mixture.charged().findWithFormula("Mg++");
-            static const auto iCl  = mixture.charged().findWithFormula("Cl-");
 
             // The number of charged species
             const auto nions = mixture.charged().size();


### PR DESCRIPTION
This PR intents to fix a bug related to cache invalidation in the Duan-Sun and Rumpf activity models. In these models some variables where declared as static, but never updated. As a result, the cached values are not invalidated between sequential computations that make use of the activity models.

In a first attempt the variables were made non-static, resolving the bug. Since this gives up caching altogether, some efficiency might be lost-- for a specific use-case I noted a runtime that took two times longer. Therefore, caching for the variables is reintroduced, with the caching object created and stored next to the `charged` species list that it is supposed to be in sync with.

@allanleal Being a first-time contributor here, I might easily have missed better options. I am all ears for suggestions.