### PR TITLE
Only install valgrind for linux in  environment.devenv.yml

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -42,7 +42,7 @@ dependencies:
   - reaktplot >=0.4.1
   - thermofun =0.4.5
   - tsl_ordered_map
-  - valgrind  # [unix]
+  - valgrind  # [linux]
   - vs2019_win-64  # [win]
   - yaml-cpp =0.7.0
   - pip:


### PR DESCRIPTION
For me on MacOS I had to comment out `valgrind` because no conda package exists.

Note that in `valgrind [unix]` the `unix` means `linux` or `macos`
https://conda-devenv.readthedocs.io/en/latest/usage.html

I think that valgrind is only supported on super-old MacOS ( see https://valgrind.org ) so effectively I don't think it can be used on MacOS. But I don't really know to be honest.