### PR TITLE
Add contribution from neutral species to the activity of water in Davies activity model

### DIFF
--- a/Reaktoro/Models/ActivityModels/ActivityModelCubicEOS.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelCubicEOS.test.cxx
@@ -22,6 +22,8 @@
 #include <Reaktoro/Models/ActivityModels/ActivityModelCubicEOS.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 // Check if the activities of the fluid species are correct assuming activity coefficients are.
 inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef props)
 {
@@ -36,6 +38,8 @@ inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef pro
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelCubicEOS", "[ActivityModelCubicEOS]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelDavies.cpp
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDavies.cpp
@@ -101,7 +101,9 @@ auto activityModelDavies(const SpeciesList& species, ActivityModelDaviesParams p
         const auto bneutrals = params.bneutrals;
         const auto sigmac = -A*(sqrtI/(1 + sqrtI) - bions*I) * ln10;
         const auto sigman = bneutrals*I * ln10;
-        const auto Gammac = 2*A*(I - 2*sqrtI + 2*log(1 + sqrtI) - 0.5*bions*I2) * ln10;
+
+        // The common integral term Γᵢ for all charged species
+        const auto Gammac = -2*A*(I - 2*sqrtI + 2*log(1 + sqrtI) - 0.5*bions*I2) * ln10;
 
         // Initialize ln activity of water to zero and collect contributions to it below from charged and neutral solutes
         ln_a[iwater] = 0.0;
@@ -122,7 +124,7 @@ auto activityModelDavies(const SpeciesList& species, ActivityModelDaviesParams p
             ln_a[ispecies] = ln_g[ispecies] + ln_m[ispecies];
 
             // Calculate the contribution of current charged species to the ln activity of water
-            ln_a[iwater] -= Mw * (m[ispecies] + m[ispecies]*ln_g[ispecies] + Gammac);
+            ln_a[iwater] -= Mw * (m[ispecies] + m[ispecies]*ln_g[ispecies] - Gammac);
         }
 
         // Loop over all neutral species in the aqueous mixture
@@ -131,6 +133,9 @@ auto activityModelDavies(const SpeciesList& species, ActivityModelDaviesParams p
             // The index of the current neutral species
             const auto ispecies = ineutral_species[i];
 
+            // The integral term Γᵢ for the neutral species
+            const auto Gammai = m[ispecies] * sigman;
+
             // Calculate the ln activity coefficient of the current neutral species
             ln_g[ispecies] = sigman;
 
@@ -138,7 +143,7 @@ auto activityModelDavies(const SpeciesList& species, ActivityModelDaviesParams p
             ln_a[ispecies] = ln_g[ispecies] + ln_m[ispecies];
 
             // Calculate the contribution of current neutral species to the ln activity of water
-            ln_a[iwater] -= Mw * m[ispecies];
+            ln_a[iwater] -= Mw * (m[ispecies] + m[ispecies]*ln_g[ispecies] - Gammai);
         }
 
         // Set the activity coefficient of water (mole fraction scale)

--- a/Reaktoro/Models/ActivityModels/ActivityModelDavies.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDavies.test.cxx
@@ -37,6 +37,7 @@ inline auto moleFractions(const SpeciesList& species) -> ArrayXr
     n[idx("OH-")] = 1e-7;
     n[idx("Na+")] = 0.3;
     n[idx("Cl-")] = 0.3;
+    n[idx("CO2")] = 0.9;
 
     return n / n.sum();
 }
@@ -78,7 +79,7 @@ TEST_CASE("Testing ActivityModelDavies", "[ActivityModelDavies]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( double(exp(props.ln_g[0]))  == Approx(0.935522783525151) ); // H2O
+        CHECK( double(exp(props.ln_g[0]))  == Approx(0.935122413217240) ); // H2O
         CHECK( double(exp(props.ln_g[1]))  == Approx(0.800165626605902) ); // H+
         CHECK( double(exp(props.ln_g[2]))  == Approx(0.800165626605902) ); // OH-
         CHECK( double(exp(props.ln_g[3]))  == Approx(0.800165626605902) ); // Na+
@@ -110,7 +111,7 @@ TEST_CASE("Testing ActivityModelDavies", "[ActivityModelDavies]")
         // Evaluate the activity props function
         fn(props, {T, P, x});
 
-        CHECK( double(exp(props.ln_g[0]))  == Approx(0.923522951483393) ); // H2O
+        CHECK( double(exp(props.ln_g[0]))  == Approx(0.923127724612841) ); // H2O
         CHECK( double(exp(props.ln_g[1]))  == Approx(0.707914308149729) ); // H+
         CHECK( double(exp(props.ln_g[2]))  == Approx(0.707914308149729) ); // OH-
         CHECK( double(exp(props.ln_g[3]))  == Approx(0.707914308149729) ); // Na+

--- a/Reaktoro/Models/ActivityModels/ActivityModelDavies.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDavies.test.cxx
@@ -25,6 +25,8 @@ using namespace Reaktoro;
 
 #define PRINT_INFO_IF_FAILS(x) INFO(#x " = \n" << std::scientific << std::setprecision(16) << x)
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -57,6 +59,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelDavies", "[ActivityModelDavies]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelDebyeHuckel.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDebyeHuckel.test.cxx
@@ -227,6 +227,8 @@ TEST_CASE("Testing ActivityModelDebyeHuckelParams", "[ActivityModelDebyeHuckel]"
     REQUIRE( params.bneutrals.empty()      );
 }
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -258,6 +260,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelDebyeHuckel", "[ActivityModelDebyeHuckel]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelDrummond.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDrummond.test.cxx
@@ -24,6 +24,8 @@
 #include <Reaktoro/Water/WaterConstants.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -55,6 +57,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelDrummond", "[ActivityModelDrummond]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelDuanSun.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelDuanSun.test.cxx
@@ -24,6 +24,8 @@
 #include <Reaktoro/Water/WaterConstants.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -55,6 +57,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelDuanSun", "[ActivityModelDuanSun]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelHKF.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelHKF.test.cxx
@@ -23,6 +23,8 @@
 #include <Reaktoro/Water/WaterConstants.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -54,6 +56,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelHKF", "[ActivityModelHKF]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelPengRobinsonPhreeqcOriginal.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelPengRobinsonPhreeqcOriginal.test.cxx
@@ -22,6 +22,8 @@
 #include <Reaktoro/Models/ActivityModels/ActivityModelPengRobinsonPhreeqcOriginal.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 // Check if the activities of the fluid species are correct assuming activity coefficients are.
 inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef props)
 {
@@ -36,6 +38,8 @@ inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef pro
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelPengRobinsonPhreeqcOriginal", "[ActivityModelPengRobinsonPhreeqcOriginal]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelRumpf.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelRumpf.test.cxx
@@ -24,6 +24,8 @@
 #include <Reaktoro/Water/WaterConstants.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -55,6 +57,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelRumpf", "[ActivityModelRumpf]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelSetschenow.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelSetschenow.test.cxx
@@ -24,6 +24,8 @@
 #include <Reaktoro/Water/WaterConstants.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 /// Return mole fractions for the species.
 inline auto moleFractions(const SpeciesList& species) -> ArrayXr
 {
@@ -55,6 +57,8 @@ inline auto checkActivities(ArrayXrConstRef x, ActivityPropsConstRef props)
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelSetschenow", "[ActivityModelSetschenow]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelSpycherPruessEnnis.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelSpycherPruessEnnis.test.cxx
@@ -22,6 +22,8 @@
 #include <Reaktoro/Models/ActivityModels/ActivityModelSpycherPruessEnnis.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 // Check if the activities of the fluid species are correct assuming activity coefficients are.
 inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef props)
 {
@@ -35,6 +37,8 @@ inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef pro
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelSpycherPruessEnnis", "[ActivityModelSpycherPruessEnnis]")
 {

--- a/Reaktoro/Models/ActivityModels/ActivityModelSpycherReed.test.cxx
+++ b/Reaktoro/Models/ActivityModels/ActivityModelSpycherReed.test.cxx
@@ -22,6 +22,8 @@
 #include <Reaktoro/Models/ActivityModels/ActivityModelSpycherReed.hpp>
 using namespace Reaktoro;
 
+namespace {
+
 // Check if the activities of the fluid species are correct assuming activity coefficients are.
 inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef props)
 {
@@ -35,6 +37,8 @@ inline auto checkActivities(ArrayXrConstRef x, real P, ActivityPropsConstRef pro
         CHECK( exp(props.ln_a[i] - props.ln_g[i]) == Approx(c[i]) );
     }
 }
+
+} // anonymous namespace
 
 TEST_CASE("Testing ActivityModelSpycherReed", "[ActivityModelSpycherReed]")
 {


### PR DESCRIPTION
This PR revises the implementation of the Davies activity model by adding contribution from neutral species to the activity of water. This contribution is determined from Gibbs-Duhem equation.

Thanks to Prof. William R. Smith (University of Guelf, Canada) and his student, William Rutherford, for identifying this issue.