### PR TITLE
Improve `SmartEquilibriumSolver` by adding a check on mass conservation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(CCache)
 include(CMakeRC)
 
 # Set the name of the project, its version and other information
-project(Reaktoro VERSION 2.12.1 LANGUAGES CXX)
+project(Reaktoro VERSION 2.12.4 LANGUAGES CXX)
 
 # Generate compile_commands.json file in the binary directory
 if(NOT MSVC)

--- a/Reaktoro/Equilibrium/SmartEquilibriumOptions.hpp
+++ b/Reaktoro/Equilibrium/SmartEquilibriumOptions.hpp
@@ -39,6 +39,9 @@ struct SmartEquilibriumOptions
     /// their respective positive lower bounds.
     double reltol_negative_amounts = -1.0e-14;
 
+    /// The relative tolerance used for the amount of species in the conservation of mass constraint.
+    double reltol_component_amount_conservation = 1.0e-10;
+
     /// The relative tolerance used in the acceptance test for the predicted chemical equilibrium state.
     double reltol = 0.005;
 


### PR DESCRIPTION
This PR introduces improvements in `SmartEquilibriumSolver`, which in some corner cases can produce predictions that do not satisfy mass conservation. This happens when a reference learned equilibrium state with a unstable species (i.e., amounts are on the lower bounds) is used to predict another and the expected equilibrium state should have one or more of those species stable.

Thanks @Jarnovr, for reporting this issue and suggesting a solution.